### PR TITLE
Fix incorrect URL on monitoring index page

### DIFF
--- a/http/src/main/scala/MonitoringServer.scala
+++ b/http/src/main/scala/MonitoringServer.scala
@@ -373,7 +373,7 @@ class MonitoringServer(M: Monitoring, port: Int, keyTTL: Duration = 36.hours) {
     |
     |        <div class="col-lg-6">
     |          <h4>Operations Resources</h4>
-    |          <p><a href="/mirror">POST /now</a>: Dynamically mirror metrics from other funnel(s).</p>
+    |          <p><a href="/mirror">POST /mirror</a>: Dynamically mirror metrics from other funnel(s).</p>
     |          <p><a href="/halt">POST /halt</a>: Stop mirroring metrics from the given funnel URLs.</p>
     |          <p><a href="/audit">GET /audit</a>: Display an aggregated view of all keys in this server broken down by previx.</p>
     |          <p><a href="/audit">GET /audit/:attribute</a>: Display an aggregated view of all keys in this server broken down by attribute key.</p>


### PR DESCRIPTION
Small typo/copy-paste-o on funnel monitoring index page.