### PR TITLE
Fix typo in code block in Developers Getting Started documentation.

### DIFF
--- a/docs/src/jekyll/getting-started/developers.md
+++ b/docs/src/jekyll/getting-started/developers.md
@@ -432,7 +432,7 @@ import funnel.http.MonitoringServer
 import funnel.Monitoring
 
 object Main {
-  def def main(args: Array[String]): Unit = {
+  def main(args: Array[String]): Unit = {
     MonitoringServer.start(Monitoring.default, 5775)
 
     // your application code starts here

--- a/docs/src/jekyll/modules/index.md
+++ b/docs/src/jekyll/modules/index.md
@@ -46,7 +46,7 @@ Using this document format enables extreamly fast indexing of documents in Elast
 
 ## Elastic Search (Exploded)
 
-**This sink is only to be used for light traffic, and at high-load it will cause yuor elastic search cluster to bloat its field space beyond the recomended safe limit. For high-volume workloads use the Flattened ES sink.**
+**This sink is only to be used for light traffic, and at high-load it will cause yuor elastic search cluster to bloat its field space beyond the recommended safe limit. For high-volume workloads use the Flattened ES sink.**
 
 Primarily for visualisation, this consumer takes the stream and aggregates into one document *per-funnel-host* per time window, and then sends those documents to Elastic Search in a bulk `PUT` operation. The format of the message looks like this:
 


### PR DESCRIPTION
Removed an extra `def` from a code block.