### PR TITLE
Minor chemist improvements

### DIFF
--- a/chemist-aws/src/main/scala/AwsConfig.scala
+++ b/chemist-aws/src/main/scala/AwsConfig.scala
@@ -22,8 +22,6 @@ import knobs._
 import funnel.aws._
 import dispatch.Http
 import java.net.InetAddress
-import scalaz.concurrent.Strategy
-import scalaz.stream.async.signalOf
 import concurrent.duration.Duration
 import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sqs.AmazonSQS

--- a/chemist-aws/src/main/scala/aws/EC2.scala
+++ b/chemist-aws/src/main/scala/aws/EC2.scala
@@ -55,8 +55,6 @@ object EC2 {
       else aggregated
     }
 
-    println(s"IIIII: ${ids.length} $ids")
-
     Task(fetch(Nil))(funnel.chemist.Chemist.serverPool)
   }
 }

--- a/chemist-aws/src/main/scala/metrics.scala
+++ b/chemist-aws/src/main/scala/metrics.scala
@@ -21,13 +21,23 @@ package aws
 import funnel.instruments._
 
 object metrics {
-  val LifecycleEvents = counter("lifecycle/events", 0, "number of lifecycle events within a given window")
+  val LifecycleEvents = counter("chemist/lifecycle/events", 0, "number of lifecycle events within a given window")
 
   object discovery {
-    val ListMonitorable = lapTimer("discovery/list/monitorable")
-    val ListUnmonitorable = lapTimer("discovery/list/unmonitorable")
-    val ListFlasks = lapTimer("discovery/list/flasks")
-    val LookupManyAws = lapTimer("discovery/lookup/aws")
-    val ValidateLatency = lapTimer("discovery/validate")
+    val ListMonitorable = lapTimer("chemist/discovery/list/monitorable")
+    val ListUnmonitorable = lapTimer("chemist/discovery/list/unmonitorable")
+    val ListFlasks = lapTimer("chemist/discovery/list/flasks")
+    val ListActiveFlasks = lapTimer("chemist/discovery/list/activeFlasks")
+    val LookupManyAws = lapTimer("chemist/discovery/aws/lookups")
+    val LookupAwsFailure = counter("chemist/discovery/aws/errors")
+    val ValidateLatency = lapTimer("chemist/discovery/validate")
+  }
+
+  object model {
+    val hostsTotal = numericGauge("chemist/hosts/total", 0)
+    val hostsValid = numericGauge("chemist/hosts/valid", 0)
+    val hostsInValid = numericGauge("chemist/hosts/invalid", 0)
+    val hostsFlask = numericGauge("chemist/hosts/flasks", 0)
+    val hostsActiveFlask = numericGauge("chemist/hosts/activeFlasks", 0)
   }
 }

--- a/chemist-aws/src/test/scala/Fixtures.scala
+++ b/chemist-aws/src/test/scala/Fixtures.scala
@@ -29,7 +29,7 @@ object Fixtures {
     datacenter: String = "us-east-1b",
     privateDns: String = "foo.internal",
     publicDns: String = "foo.ext.amazonaws.com",
-    tags: Seq[(String,String)] = Seq("baz" -> "v1","bar" -> "v2")
+    tags: Seq[(String,String)] = Seq("baz" -> "v1","bar" -> "v2","funnel:mirror:uri-template"->"http://@host:5775")
   ): EC2Instance =
     (new EC2Instance).withInstanceId(id)
     .withPlacement(new Placement(datacenter))
@@ -45,7 +45,7 @@ object Fixtures {
     instance("i-dx947af7") ::
     instance("i-15807647") ::
     instance("i-flaskAAA",
-      tags = Vector(AwsTagKeys.name -> "flask")
+      tags = Vector(AwsTagKeys.name -> "flask", "funnel:mirror:uri-template"->"http://@host:5775")
     ) :: Nil
 
   val localhost: Location =

--- a/chemist-aws/src/test/scala/LifecycleSpec.scala
+++ b/chemist-aws/src/test/scala/LifecycleSpec.scala
@@ -21,14 +21,9 @@ package aws
 import org.scalatest.{FlatSpec,Matchers}
 import com.amazonaws.services.sqs.AmazonSQS
 import com.amazonaws.services.autoscaling.AmazonAutoScaling
-import scalaz.concurrent.Strategy
-import scalaz.{\/,\/-,-\/,==>>}
-import scalaz.stream.{Process,Sink}
+import scalaz.{\/,\/-}
+import scalaz.stream.Process
 import scalaz.concurrent.Task
-import scalaz.stream.async.signalOf
-import scalaz.stream.async.mutable.Signal
-import scalaz.std.string._
-import Sharding.Distribution
 
 class LifecycleSpec extends FlatSpec with Matchers {
   import PlatformEvent._
@@ -67,10 +62,6 @@ class LifecycleSpec extends FlatSpec with Matchers {
   }
 
   behavior of "Lifecycle.interpreter"
-
-  import scalaz.syntax.traverse._
-  import scalaz.{Unapply,Traverse}
-  import scalaz.syntax.either._
 
   def check(json: String): Task[Throwable \/ Seq[PlatformEvent]] =
     Lifecycle.parseMessage(TestMessage(json)

--- a/chemist/src/main/scala/Cacheable.scala
+++ b/chemist/src/main/scala/Cacheable.scala
@@ -30,9 +30,6 @@ trait Cacheable[A]{
   def cache(a: Context[A], to: StateCache): Task[Unit]
 }
 object Cacheable {
-  import scalaz.syntax.apply._
-  import Sharding.Distribution
-
   private[this] val log = Logger[Cacheable.type]
 
   implicit val planCachable: Cacheable[Plan] =
@@ -52,8 +49,7 @@ object Cacheable {
           case Context(d, p) =>
             for {
               _ <- to.plan(in.value)
-              _  = log.debug(s"value = ${in.value}")
-              _  = log.debug(s"distribution = ${in.distribution}")
+              _  = log.debug(s"[cache] value = ${in.value} distribution = ${in.distribution}")
               _ <- to.distribution(in.distribution)
             } yield ()
         }

--- a/chemist/src/main/scala/Discovery.scala
+++ b/chemist/src/main/scala/Discovery.scala
@@ -57,10 +57,10 @@ trait Discovery {
    * The reason this is not simply the inverted version of `isActiveFlask`
    * is that when asking for targets, we specifically do not want any
    * Flasks, active or otherwise, because mirroring a Flask from another
-   * Flask risks a cascading failure due to key amplication (essentially
-   * mirroring the mirrorer whilst its mirroring etc).
+   * Flask risks a cascading failure due to key amplification (essentially
+   * mirroring the mirrored whilst its mirroring etc).
    *
-   * To mittigate this, we specifically call out anything that is not
+   * To mitigate this, we specifically call out anything that is not
    * classified as an `ActiveTarget`
    *
    * @see funnel.chemist.Classifier

--- a/chemist/src/main/scala/Location.scala
+++ b/chemist/src/main/scala/Location.scala
@@ -76,8 +76,8 @@ case class Location(
 object Location {
 
   /**
-   * Given a `java.net.URI`, attempt to conver this into a `Location`
-   * instance. This is not guarenteed to work, and there are a range
+   * Given a `java.net.URI`, attempt to convert this into a `Location`
+   * instance. This is not guaranteed to work, and there are a range
    * of failure cases because of the problems with the way `URI` is
    * actually implemented within the JDK. With that being said, for
    * our purposes, this works as our URIs are always well formed -

--- a/chemist/src/main/scala/Pipeline.scala
+++ b/chemist/src/main/scala/Pipeline.scala
@@ -65,7 +65,7 @@ object Pipeline {
 
   /**
    * grab the existing work from the shards, and update the distribution;
-   * our view of the world as it is right now (stale and immedietly non-authoritive)
+   * our view of the world as it is right now (stale and immediately non-authoritative)
    */
   def collect(http: dispatch.Http)(d: Distribution): Task[Distribution] =
     Flask.gatherAssignedTargets(Sharding.shards(d))(http)
@@ -78,7 +78,7 @@ object Pipeline {
       sharder.distribution(Set(target))(d)._2 // drop the seq, as its not needed
 
     /**
-     * in the event more capacity becomes avalible, rebalence the cluster to take
+     * in the event more capacity becomes available, rebalance the cluster to take
      * best advantage of that new capacity using the specified sharder to
      * redistribute the work. This function is soley responsible for orchestrating
      * the inputs/outputs of the sharder, and the actual imlpementaiton logic of

--- a/chemist/src/main/scala/flask.scala
+++ b/chemist/src/main/scala/flask.scala
@@ -53,8 +53,6 @@ object Flask {
    * If some flasks are down then they will not be returned as part of distribution
    * and should not be allocated work too. This might lead to double work assignment in case of
    * network partitioning but Chemist need to be able to correct double assignment issues anyways.
-   *
-   * This function should only really be used startup of chemist. //wrong??? part of discovery and it is periodic
    */
   def gatherAssignedTargets(flasks: Seq[Flask])(http: dispatch.HttpExecutor): Task[Distribution] = {
     val lookups = Nondeterminism[Task].gatherUnordered(

--- a/chemist/src/main/scala/metrics.scala
+++ b/chemist/src/main/scala/metrics.scala
@@ -20,7 +20,11 @@ package chemist
 import funnel.instruments._
 
 object metrics {
-  val GatherAssignedLatency = lapTimer("pipeline/gather-assigned-latency")
-  val MonitorCommandLatency = lapTimer("commands/monitor")
-  val UnmonitorCommandLatency = lapTimer("commands/unmonitor")
+  val GatherAssignedLatency = lapTimer("chemist/pipeline/gather-assigned-latency")
+  val MonitorCommandLatency = lapTimer("chemist/commands/monitor")
+  val UnmonitorCommandLatency = lapTimer("chemist/commands/unmonitor")
+
+  val deadFlasks   = numericGauge("chemist/flasks/dead", 0)
+  val liveFlasks   = numericGauge("chemist/flasks/live", 0)
+  val knownSources = numericGauge("chemist/flasks/sources", 0)
 }

--- a/chemist/src/test/scala/FlaskSpec.scala
+++ b/chemist/src/test/scala/FlaskSpec.scala
@@ -1,0 +1,52 @@
+package funnel.chemist
+
+import org.scalatest.{Matchers, FlatSpec}
+import Fixtures._
+
+class FlaskSpec extends FlatSpec with Matchers {
+
+  private val t = LocationTemplate(s"http://@host:@port/mirror/sources")
+
+  val fakeHttp = FakeHttpExecutor(
+    Map(
+      flask01.location.uriFromTemplate(t).toString ->
+        """
+          |[
+          |  {"cluster":"app1-7.0.317","uris":["http://ip-10-123-214-77.ec2.internal:5775/stream/now?type=%22String%22"]},
+          |  {"cluster":"app2-3.0.91", "uris":["http://ip-10-123-216-55.ec2.internal:5775/stream/now?type=%22String%22"]}
+          |]
+        """.stripMargin,
+      flask02.location.uriFromTemplate(t).toString ->
+        """
+          |[
+          |  {"cluster":"app3-2.1.1","uris":["http://ip-10-123-215-88.ec2.internal:5775/stream/now?type=%22String%22"]},
+          |  {"cluster":"app4-1.1.1","uris":["http://ip-10-123-215-99.ec2.internal:5775/stream/now?type=%22String%22"]},
+          |  {"cluster":"app5-3.0.92","uris":["http://ip-10-123-216-66.ec2.internal:5775/stream/now?type=%22String%22"]}
+          |]
+        """.stripMargin,
+      flask03.location.uriFromTemplate(t).toString -> "[]"
+    )
+  )
+
+  it should "do not fail on dead flask" in {
+    val d = Flask.gatherAssignedTargets(flasks = Seq(flask04))(fakeHttp).run
+
+    d.isEmpty should equal(true)
+  }
+
+  it should "aggregate data from multiple flasks" in {
+    val d = Flask.gatherAssignedTargets(flasks = Seq(flask01, flask02, flask03))(fakeHttp).run
+
+    d.keySet should equal(Set(flask01, flask02, flask03))
+    d.lookup(flask01).map(_.size) should equal(Some(2))
+    d.lookup(flask03).map(_.size) should equal(Some(0))
+  }
+
+  it should "partially aggregate data from multiple flasks if some are dead" in {
+    //flask4 is not part of fakeHttp
+    val d = Flask.gatherAssignedTargets(flasks = Seq(flask04, flask01, flask02))(fakeHttp).run
+
+    d.keySet should equal(Set(flask01, flask02))
+    d.lookup(flask01).map(_.size) should equal(Some(2))
+  }
+}

--- a/core/src/main/scala/Monitoring.scala
+++ b/core/src/main/scala/Monitoring.scala
@@ -147,7 +147,7 @@ trait Monitoring {
     def modifyActive(b: ClusterName, f: Set[URI] => Set[URI]): Task[Unit] = {
       for {
         _ <- active.compareAndSet(a => Option(f(a.getOrElse(Set.empty[URI]))))
-        _ <- Task(clusterUrls.update(_.alter(b, s => Option(f(s.getOrElse(Set.empty[URI]))))).filter(!_.isEmpty))(defaultPool)
+        _ <- Task(clusterUrls.update(_.alter(b, s => Option(f(s.getOrElse(Set.empty[URI]))))).filter(_.nonEmpty))(defaultPool)
         _  = log.debug(s"modified the active uri set for $b: ${clusterUrls.get.lookup(b).getOrElse(Set.empty)}")
       } yield ()
     }

--- a/core/src/main/scala/Reportable.scala
+++ b/core/src/main/scala/Reportable.scala
@@ -17,7 +17,7 @@
 package funnel
 
 /**
- * A type, `A`, constained to be either `Int`,
+ * A type, `A`, constrained to be either `Int`,
  * `Double`, `String`, or `Stats`.
  */
 sealed trait Reportable[+A] { self =>
@@ -30,7 +30,7 @@ sealed trait Reportable[+A] { self =>
 
 object Reportable {
   /**
-   * used to make sure scalacheck is generating all possiblilites, if
+   * used to make sure scalacheck is generating all possibilities, if
    * you add a new one, please update this
    */
   def all: Seq[Reportable[Any]] = Seq(B,D,S,Stats)

--- a/elastic/src/main/scala/ElasticExploded.scala
+++ b/elastic/src/main/scala/ElasticExploded.scala
@@ -25,7 +25,7 @@ import scalaz.concurrent.Strategy.Executor
 import scalaz.stream.{Process1,Process,time,async,wye}
 
 /**
- * This class provides a consumer for the funnel montioring stream that takes
+ * This class provides a consumer for the funnel monitoring stream that takes
  * the events emitted and constructs a JSON document that will be sent to elastic
  * search. The names of the metrics on the stream are expected to be delimited
  * by a `/`, which will then be exploded into a tree of fields.

--- a/elastic/src/main/scala/ElasticFlattened.scala
+++ b/elastic/src/main/scala/ElasticFlattened.scala
@@ -25,10 +25,10 @@ import java.text.SimpleDateFormat
 import scalaz.concurrent.Strategy.Executor
 
 /**
- * This class provides a consumer for the funnel montioring stream that takes
+ * This class provides a consumer for the funnel monitoring stream that takes
  * the events emitted and constructs a JSON document that will be sent to elastic
  * search. Each and every metric key has its own individual document, where fields
- * are flattened into a simplistic structure, which is optiomal for the manner in
+ * are flattened into a simplistic structure, which is optimal for the manner in
  * which elastic search stores documents and manages in-memory indexing with Lucene.
  *
  * {
@@ -89,13 +89,13 @@ case class ElasticFlattened(M: Monitoring){
       case _ => ("unknown", keyname) // should not happen; what would it mean?
     }
     val attrs = pt.key.attributes
-    val source: String = attrs.get(AttributeKeys.source).getOrElse(flaskNameOrHost)
+    val source: String = attrs.getOrElse(AttributeKeys.source, flaskNameOrHost)
     val host: String = attrs.get(AttributeKeys.source
       ).map(u => (new URI(u)).getHost).getOrElse(flaskNameOrHost)
     val experimentId: Option[String] = attrs.get(AttributeKeys.experimentID)
     val experimentGroup: Option[String] = attrs.get(AttributeKeys.experimentGroup)
     val kind: Option[String] = attrs.get(AttributeKeys.kind).map(_.toLowerCase)
-    val cluster: String = attrs.get(AttributeKeys.cluster).getOrElse(flaskCluster)
+    val cluster: String = attrs.getOrElse(AttributeKeys.cluster, flaskCluster)
     val units: String = pt.units.toString.toLowerCase
     val edge: Option[String] = attrs.get(AttributeKeys.edge)
     val keytype: String = pt.typeOf.description.toLowerCase
@@ -124,7 +124,7 @@ case class ElasticFlattened(M: Monitoring){
      * this was the best path right now. (*sigh*)
      *
      * likewise, the hack here with elapsed, remaining and uptime is because they
-     * are currently inccorectly reporting themselves as kind=timer, which then
+     * are currently incorrectly reporting themselves as kind=timer, which then
      * screws up the mapping because we expect timers to be a `Stats` instance. To
      * workaround this bug, i've added this hack until we can migrate users to a
      * newer version of funnel core in the leaves of our system.
@@ -133,7 +133,7 @@ case class ElasticFlattened(M: Monitoring){
       kind.map { k =>
         val value = (pt.asJson -| "value").get
         if(k == "gauge")
-          Json((s"${kind.get}-${keytype}") -> value)
+          Json(s"${kind.get}-$keytype" -> value)
         else if(name == "elapsed" || name == "remaining" || name == "uptime")
           Json(name -> value)
         else


### PR DESCRIPTION
In addition to log/metrics improvements i am changing following:
  1) failure to fetch sources from one of the flasks will not fail creation of distribution (based on partial data). This helps with "dead" flasks nodes (i.e. node alive, flask is down)

  2) remove default template notion from chemist-aws. If instances is not labelled with funnel tags then it is considered to be not eligible. This helps to not try to connect to these instances again and again