### PR TITLE
Refactoring Elastic module to make it more testable and survive errors

### DIFF
--- a/elastic/src/main/scala/Elastic.scala
+++ b/elastic/src/main/scala/Elastic.scala
@@ -18,7 +18,6 @@ package funnel
 package elastic
 
 import argonaut._
-import knobs.IORef
 import java.io.File
 import journal.Logger
 import java.util.Date
@@ -27,8 +26,7 @@ import scala.util.control.NonFatal
 import scalaz.stream.Process
 import scalaz.concurrent.{Task,Strategy}
 import Process.constant
-import scala.concurrent.{Future,ExecutionContext}
-import scalaz.{\/,Kleisli,Monad,~>,Reader,Nondeterminism}
+import scalaz._
 import scalaz.stream.async.mutable.ScalazHack
 
 object Elastic {
@@ -36,7 +34,7 @@ object Elastic {
   import Kleisli.ask
   import scalaz.syntax.kleisli._
   import scalaz.syntax.monad._ // pulls in *>
-  import concurrent.duration._
+  import scala.concurrent.duration._
   import metrics._
 
   type SourceURL = String
@@ -47,14 +45,6 @@ object Elastic {
   type ES[A] = Kleisli[Task, ElasticCfg, A]
 
   private[this] val log = Logger[Elastic.type]
-
-  /**
-   * Given a scala future, convert it to task when the future completes
-   */
-  def fromScalaFuture[A](a: => Future[A])(implicit e: ExecutionContext): Task[A] =
-    Task async { k =>
-      a.onComplete {
-        t => k(\/.fromTryCatchNonFatal[A](t.get)) }}
 
   /**
    *
@@ -79,35 +69,7 @@ object Elastic {
   /**
    * get a handle on the subscriptionTimeout without having an ES instance
    */
-  def duration: Reader[ElasticCfg, FiniteDuration] =
-    Reader { es => es.subscriptionTimeout }
-
-  /****************************** http i/o ******************************/
-
-  import dispatch._, Defaults._
-
-  /**
-   * sadly required as dispatch has a very naïve error handler by default,
-   * and in this case we're looking to output the body of the response to the log
-   * in order to help with debugging in the event documents were not able to be
-   * submitted to the backend. Should function exactly like the default impl
-   * with the addition of the logging.
-   */
-  val handler = new FunctionHandler[String]({ resp =>
-    val status = resp.getStatusCode
-    if((status / 100) == 2) resp.getResponseBody
-    else {
-      log.error(s"Backend returned a code ${resp.getStatusCode} failure. Body response was: ${resp.getResponseBody}")
-      throw StatusCode(status)
-    }
-  })
-
-  /**
-   * given a request, and a payload, compresses the payload into a single-line
-   * string and POSTs it to elastic search.
-   */
-  def elasticJson(req: Req, json: Json): ES[Unit] =
-    elastic(req, json.nospaces)
+  def duration: Reader[ElasticCfg, FiniteDuration] = Reader { es => es.subscriptionTimeout }
 
   /**
    * build a function that sends string-like inputs to the specified request
@@ -115,20 +77,16 @@ object Elastic {
    *
    * @see funnel.elastic.Elastic.handler
    */
-  def elasticString(req: Req): ES[String] = {
-    getConfig.flatMapK(c => fromScalaFuture(c.http(req > handler)))
-  }
+  def elasticString(req: HttpOp)(H: HttpLayer): ES[String] = H.http(req)
 
   /**
    * send the supplied json string to the configured elastic search endpoint
    * using HTTP POST.
    */
-  def elastic(req: Req, json: String): ES[Unit] = for {
-    es <- getConfig
-    ta <- lower(elasticString(req << json))
+  def elastic(req: HttpOp)(H: HttpLayer): ES[Unit] = for {
+    ta <- lower(elasticString(req)(H))
     _  <- lift(ta.attempt.map(_.fold(
-      e => {log.error(s"Unable to send document to elastic search due to '$e'.")
-            log.error(s"Configuration was $es. Document was: \n $json")},
+      e => log.error(s"Unable to send document to elastic search due to '$e'. Request was: \n $req"),
       _ => ())))
   } yield ()
 
@@ -138,24 +96,23 @@ object Elastic {
   def retry[A](task: Task[A]): Task[A] = {
     val schedule = Stream.iterate(2)(_ * 2).take(30).map(_.seconds)
     val t = task.attempt.flatMap(_.fold(
-      e => e match {
-        case StatusCode(digits) =>
+      {
+        case e: HttpException =>
           Task.delay {
-            val r: Int = digits / 100
-            if(r == 5) HttpResponse5xx.increment
-            else if (r == 4) HttpResponse4xx.increment
+            if (e.serverError) HttpResponse5xx.increment
+            else if (e.clientError) HttpResponse4xx.increment
           }.flatMap(_ => Task.fail(e))
-        case _ =>
+        case e =>
           Task.delay {
-            log.error(s"Error contacting ElasticSearch: $e.\nRetrying...")
+            log.error(s"Error contacting ElasticSearch: $e. Retrying...")
             NonHttpErrors.increment
           } >>= (_ => Task.fail(e))
       },
       a => Task.now(a)
     ))
-    t.retry(schedule, (e: Throwable) => e.getCause match {
-      case StatusCode(code) => false
-      case NonFatal(_) => true
+    t.retry(schedule, {
+      case HttpException(_) => false
+      case e@NonFatal(_) => true
       case _ => false
     })
   }
@@ -166,91 +123,113 @@ object Elastic {
   def bufferAndPublish(
     flaskName: String,
     flaskCluster: String
-  )(M: Monitoring, E: Strategy
+  )(M: Monitoring, E: Strategy, H: HttpLayer
   )(jsonStream: ElasticCfg => Process[Task, Json]): ES[Unit] = {
-    // val E = Executor(Monitoring.defaultPool)
     def doPublish(de: Process[Task, Json], cfg: ElasticCfg): Process[Task, Unit] =
-      de to constant((json: Json) => for {
-        r <- Task.delay(esURL(cfg))
-        _ <- retry( HttpResponse2xx.timeTask(elasticJson(r.POST, json)(cfg)) )
-      } yield ())
+      de to constant(
+        (json: Json) => retry(HttpResponse2xx.timeTask(
+          for {
+            //delaying task is important here. Otherwise we will not really retry to send http request
+            u <- Task.delay(esURL)
+            _ <- H.http(POST(u, Reader((cfg: ElasticCfg) => json.nospaces)))(cfg)
+          } yield ()
+        )).attempt.map {
+          case \/-(v) => ()
+          case -\/(t) =>
+            //if we fail to publish metric, proceed to the next one
+            // TODO: consider circuit breaker on ES failures (embed into HttpLayer)
+            // TODO: how does publishing dies when flasks stops monitoring target? do we release resources?
+            log.warn(s"[elastic] failed to publish. error=$t data=$json ")
+            metrics.BufferDropped.increment
+            ()
+        }
+      )
+
     for {
-      cfg <- getConfig
-      _ = log.info(s"Ensuring Elastic template ${cfg.templateName} exists...")
-      _   <- ensureTemplate
-      _ = log.info(s"Initializing Elastic buffer of size ${cfg.bufferSize}...")
-      buffer = ScalazHack.observableCircularBuffer[Json](cfg.bufferSize, metrics.BufferDropped, metrics.BufferUsed)(E)
-      ref <- lift(IORef(Set[Key[Any]]()))
-      d   <- duration.lift[Task]
-      _ = log.info(s"Started Elastic subscription")
-      // Reads from the monitoring instance and posts to the publishing queue
-      read = jsonStream(cfg).to(buffer.enqueue)
-      // Reads from the publishing queue and writes to ElasticSearch
-      write  = doPublish(buffer.dequeue, cfg)
-      _ <- lift(Nondeterminism[Task].reduceUnordered[Unit, Unit](Seq(read.run, write.run)))
-    } yield ()
+      _ <- ensureTemplate(H)
+      r <- Kleisli.kleisli[Task, ElasticCfg, Unit] {
+        (cfg: ElasticCfg) =>
+          log.info(s"Initializing Elastic buffer of size ${cfg.bufferSize}...")
+          val buffer = ScalazHack.observableCircularBuffer[Json](
+            cfg.bufferSize, metrics.BufferDropped, metrics.BufferUsed
+          )(E)
+
+          log.info(s"Started Elastic subscription")
+          // Reads from the monitoring instance and posts to the publishing queue
+          val read = jsonStream(cfg).to(buffer.enqueue)
+          // Reads from the publishing queue and writes to ElasticSearch
+          val write = doPublish(buffer.dequeue, cfg)
+          Nondeterminism[Task].reduceUnordered[Unit, Unit](Seq(read.run, write.run))
+      }
+    } yield r
   }
 
   /****************************** indexing ******************************/
 
   /**
    * construct the actual url to send documents to based on the configuration
-   * paramaters, taking into account the index data pattern and prefix.
+   * parameters, taking into account the index data pattern and prefix.
    */
-  def indexURL: Reader[ElasticCfg, Req] = Reader { es =>
+  def indexURL: Reader[ElasticCfg, String] = Reader { es =>
     val date = new SimpleDateFormat(es.dateFormat).format(new Date)
-    url(s"${es.url}/${es.indexName}-$date")
+    s"${es.url}/${es.indexName}-$date"
   }
 
   /**
    * given the ES url, make sure that all our requests are properly set with
    * the application/json content mime type.
    */
-  def esURL: Reader[ElasticCfg, Req] = Reader { es =>
-    (indexURL(es) / es.typeName).setContentType("application/json", "UTF-8")
+  def esURL: Reader[ElasticCfg, String] = Reader {
+    es => s"${indexURL(es)}/${es.typeName}"
+  }
+
+  private def esTemplateURL: Reader[ElasticCfg, String] = Reader {
+    es => s"${es.url}/_template/${es.templateName}"
+  }
+
+  private def esTemplate: Reader[ElasticCfg, String] = Reader {
+    cfg => cfg.templateLocation.map(
+      f => scala.io.Source.fromFile(new File(f).getAbsolutePath).mkString
+    ).getOrElse(
+      sys.error("no index mapping template specified.")
+    )
   }
 
   /**
    * returns true if the index was created. False if it already existed.
    */
-  def ensureIndex(url: Req): ES[Boolean] =
-    ensureExists(url, createIndex(url))
+  def ensureIndex(url: Reader[ElasticCfg, String])(H: HttpLayer): ES[Boolean] =
+    ensureExists(
+      HEAD(url),
+      //create index
+      PUT(url, Reader((cfg: ElasticCfg) => Json("settings" := Json("index.cache.query.enable" := true)).nospaces))
+    )(H)
 
   /**
    * ensure the index we are trying to send documents too (defined in the config)
    * exists in the backend elastic search cluster.
    */
-  def ensureExists(url: Req, action: ES[Unit]): ES[Boolean] = for {
-    s   <- elasticString(url.HEAD).mapK(_.attempt)
-    b   <- s.fold(
-             e => e.getCause match {
-               case StatusCode(404) => action *> lift(Task.now(true))
-               case _ => lift(Task.fail(e)) // SPLODE!
-             },
-             _ => lift(Task.now(false)))
-  } yield b
-
-  /**
-   * create an index based on the
-   */
-  def createIndex(url: Req): ES[Unit] =
+  def ensureExists(check: HttpOp, action: HttpOp)(H: HttpLayer): ES[Boolean] =
     for {
-      _ <- elasticJson(url.PUT, Json("settings" := Json("index.cache.query.enable" := true)))
-    } yield ()
+      s <- H.http(check).mapK(_.attempt)
+      b <- s.fold(
+             {
+               case HttpException(404) => H.http(action).map(_ => true)
+               case e => lift(Task.fail(e)) // SPLODE!
+             },
+             z => lift(Task.now(false))
+             )
+  } yield b
 
   /**
    * load the template specified in the configuration and send it to the index
    * to ensure that all the document fields we publish are correctly handled by
    * elastic search / kibana.
    */
-  def ensureTemplate: ES[Unit] = for {
-    cfg <- getConfig
-    template <- Task.delay(
-      cfg.templateLocation.map(f => scala.io.Source.fromFile(new File(f).getAbsolutePath)) getOrElse
-        sys.error("no index mapping template specified.")).liftKleisli
-    json <- Task.delay(template.mkString).liftKleisli
-    turl = url(s"${cfg.url}") / "_template" / cfg.templateName
-    _ <- ensureExists(turl, elastic(turl.PUT, json))
-  } yield ()
-
+  def ensureTemplate(H: HttpLayer): ES[Unit] = ensureExists(
+    HEAD(
+      esTemplateURL.map {s => log.info(s"Ensuring Elastic template $s exists..."); s }
+    ),
+    PUT(esTemplateURL, esTemplate)
+  )(H).map(_ => ())
 }

--- a/elastic/src/main/scala/HttpLayer.scala
+++ b/elastic/src/main/scala/HttpLayer.scala
@@ -1,0 +1,113 @@
+//: ----------------------------------------------------------------------------
+//: Copyright (C) 2015 Verizon.  All Rights Reserved.
+//:
+//:   Licensed under the Apache License, Version 2.0 (the "License");
+//:   you may not use this file except in compliance with the License.
+//:   You may obtain a copy of the License at
+//:
+//:       http://www.apache.org/licenses/LICENSE-2.0
+//:
+//:   Unless required by applicable law or agreed to in writing, software
+//:   distributed under the License is distributed on an "AS IS" BASIS,
+//:   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//:   See the License for the specific language governing permissions and
+//:   limitations under the License.
+//:
+//: ----------------------------------------------------------------------------
+package funnel.elastic
+
+import journal.Logger
+import scala.concurrent.{ExecutionContext, Future}
+import scalaz._
+import scalaz.concurrent.Task
+
+/**
+  * Simple abstraction of ES HTTP API (so we can mock it in the tests)
+  */
+sealed trait HttpOp {
+  def url: Reader[ElasticCfg, String]
+}
+
+case class POST(url: Reader[ElasticCfg, String], body: Reader[ElasticCfg, String]) extends HttpOp
+
+case class GET(url: Reader[ElasticCfg, String]) extends HttpOp
+
+case class HEAD(url: Reader[ElasticCfg, String]) extends HttpOp
+
+case class PUT(url: Reader[ElasticCfg, String], body: Reader[ElasticCfg, String]) extends HttpOp
+
+case class HttpException(code: Int) extends RuntimeException {
+  def serverError = code >= 500
+  def clientError = code >= 400 && code < 500
+
+  override def toString() = s"HttpException($code)"
+}
+
+trait HttpLayer {
+  def http(v: HttpOp): Elastic.ES[String]
+}
+
+//Dispatch-based implementation
+trait DispatchHttpLayer extends HttpLayer {
+  private[this] val log = Logger[Elastic.type]
+
+  /**
+    * Given a scala future, convert it to task when the future completes
+    */
+  private def fromScalaFuture[A](a: => Future[A])(implicit e: ExecutionContext): Task[A] =
+    Task async { k =>
+      a.onComplete {
+        t => k(\/.fromTryCatchNonFatal[A](t.get)) }}
+
+  /****************************** http i/o ******************************/
+
+  import dispatch._, Defaults._
+
+  /**
+    * sadly required as dispatch has a very naïve error handler by default,
+    * and in this case we're looking to output the body of the response to the log
+    * in order to help with debugging in the event documents were not able to be
+    * submitted to the backend. Should function exactly like the default impl
+    * with the addition of the logging.
+    */
+  private val handler = new FunctionHandler[String]({ resp =>
+    val status = resp.getStatusCode
+    if((status / 100) == 2) resp.getResponseBody
+    else {
+      log.error(s"Backend returned a code ${resp.getStatusCode} failure. Body response was: ${resp.getResponseBody}")
+      throw StatusCode(status)
+    }
+  })
+
+//  def post(json: Json) = StatusCode
+
+  private def req(v: HttpOp): Kleisli[Id.Id, ElasticCfg, Req] = v match {
+    case PUT(u, b) => for {
+      uri <- u
+      body <- b
+    } yield url(uri).PUT.setContentType("application/json", "UTF-8") << body
+
+    case POST(u, b) => for {
+      uri <- u
+      body <- b
+    } yield url(uri).POST.setContentType("application/json", "UTF-8") << body
+
+    case GET(u) => u.map(s => url(s).GET)
+    case HEAD(u) => u.map(s => url(s).GET)
+  }
+
+  def http(v: HttpOp): Elastic.ES[String] =
+    Kleisli.kleisli(
+      (cfg: ElasticCfg) =>
+        for {
+          r <- Task.delay(req(v)(cfg))
+          response <- fromScalaFuture(cfg.http(r > handler)).handleWith {
+            case e: StatusCode => Task.fail(HttpException(e.code))
+          }
+        } yield response
+    )
+}
+
+object SharedHttpLayer {
+  val H = new DispatchHttpLayer {}
+}

--- a/elastic/src/main/scala/metrics.scala
+++ b/elastic/src/main/scala/metrics.scala
@@ -18,13 +18,13 @@ package funnel
 package elastic
 
 //Needed for static initialization of JVM Metrics
-import instruments._
 import scala.concurrent.duration._
 
 object metrics {
   //report these metrics every 30 seconds
   val i = new Instruments(bufferTime = 30 seconds)
 
+  val DroppedDocErrors = i.counter("elastic/errors/dropped")
   val NonHttpErrors    = i.counter("elastic/errors/other")
   val HttpResponse5xx  = i.counter("elastic/http/5xx")
   val HttpResponse4xx  = i.counter("elastic/http/4xx")

--- a/elastic/src/test/scala/ExplodedTest.scala
+++ b/elastic/src/test/scala/ExplodedTest.scala
@@ -28,10 +28,12 @@ object ExplodedTest extends P("elastic") {
    h <- genHost
   } yield Key[Stats](n, Units.Count, "description", Map(AttributeKeys.source -> h))
 
-  val datapoint = for {
+  val datapoint = Option(Datapoint(Key[Stats]("n1", Units.Count, "description", Map(AttributeKeys.source -> "h1")), 3))
+
+/*    for {
     k <- genKey
-    d <- Gen.posNum[Double]
-  } yield Option(Datapoint(k, d))
+    //d <- Gen.posNum[Double]
+  } yield Option(Datapoint(k, 3 /*d */)) */
 
   val E = ElasticExploded(Monitoring.default)
 

--- a/elastic/src/test/scala/ExplodedTest.scala
+++ b/elastic/src/test/scala/ExplodedTest.scala
@@ -28,7 +28,7 @@ object ExplodedTest extends P("elastic") {
    h <- genHost
   } yield Key[Stats](n, Units.Count, "description", Map(AttributeKeys.source -> h))
 
-  val datapoint = Option(Datapoint(Key[Stats]("n1", Units.Count, "description", Map(AttributeKeys.source -> "h1")), 3))
+  val datapoint = Option(Datapoint(Key[Stats]("n1", Units.Count, "description", Map(AttributeKeys.source -> "h1")), Stats(3)))
 
 /*    for {
     k <- genKey

--- a/elastic/src/test/scala/FlattendedSpec.scala
+++ b/elastic/src/test/scala/FlattendedSpec.scala
@@ -17,9 +17,20 @@
 package funnel
 package elastic
 
+import java.io.IOException
+import java.net.URI
+import java.util.concurrent.{ThreadFactory, Executors, ExecutorService}
 import org.scalatest.{FlatSpec,Matchers}
+import org.scalatest.concurrent._
+import org.scalatest.time._
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scalaz.Kleisli
+import scalaz.concurrent.Task
+import scalaz.stream.Process
 
-class FlattenedSpec extends FlatSpec with Matchers {
+class FlattenedSpec extends FlatSpec with Matchers with Eventually {
   val F = ElasticFlattened(Monitoring.default)
 
   def point =
@@ -37,11 +48,188 @@ class FlattenedSpec extends FlatSpec with Matchers {
       Map(AttributeKeys.source -> "http://10.0.10.10/stream/now", AttributeKeys.kind -> "gauge")
     ), Stats(3.14))
 
-  // TIM: christ, we need more tests here. sorry!
+
+  val sharedCfg = new ElasticCfg("http://some-host", "idx", "a", "yyyy.MM.ww", "template",
+    Some("version.sbt"),
+    http = null,
+    List("previous"),
+    subscriptionTimeout = 300.millis, bufferSize = 4096)
+
+  case class MonitoringEnv(M: Monitoring, I: Instruments, EF: ElasticFlattened, H: InMemoryHttpLayer) {
+    private def taskRun[A](t: Duration)(op: Task[A]): java.util.concurrent.atomic.AtomicBoolean = {
+      val b = new java.util.concurrent.atomic.AtomicBoolean(false)
+      op.runAsyncInterruptibly(t => (), b)
+      b
+    }
+
+    private def processRun[A](t: Duration)(p: Process[Task, A]): java.util.concurrent.atomic.AtomicBoolean = {
+      val b = new java.util.concurrent.atomic.AtomicBoolean(false)
+      p.run.runAsyncInterruptibly(_ => (), b)
+      b
+    }
+
+    // starts publishing process and returns function to stop it
+    def publish(): () => Unit = {
+      val s1 = taskRun(10.seconds)(EF.publish("env", "a1", "a2")(sharedCfg))
+      val s2 = processRun(10.seconds)(M.dataDislodgement)
+
+      () => {
+        s1.set(true)
+        s2.set(true)
+        ()
+      }
+    }
+  }
+
+  private def daemonThreads(name: String) = new ThreadFactory {
+    def newThread(r: Runnable) = {
+      val t = Executors.defaultThreadFactory.newThread(r)
+      t.setDaemon(true)
+      t.setName(name)
+      t
+    }
+  }
+
+  def monitoringEnv(rules: Seq[Rule] = Rule.defaultRules(sharedCfg))(testCode: (MonitoringEnv) => Any): Unit =
+    monitoringEnv(InMemoryHttpLayer(rules))(testCode)
+
+  def monitoringEnv(httpLayer: InMemoryHttpLayer)(testCode: (MonitoringEnv) => Any): Unit = {
+    val pool: ExecutorService = Executors.newFixedThreadPool(8, daemonThreads("test-threads"))
+
+    val M = Monitoring.instance(ES = pool, windowSize = 50.millis)
+
+    val ef = ElasticFlattened(M, httpLayer)
+    val instruments = new Instruments(M, bufferTime = 20 millis)
+
+    val env = MonitoringEnv(M, instruments, ef, httpLayer)
+
+    try {
+      testCode(env)
+    } finally {
+      pool.shutdownNow()
+    }
+  }
 
   "toJson" should "correctly render documents to json in the happy case" in {
     println {
       F.toJson("dev", "127.0.0.1", "local")(point3)
     }
+  }
+
+
+  "template provisioning" should "provision template if missing" in
+    monitoringEnv(Seq(Rule.failedPUT(s"/_template/${sharedCfg.templateName}", 999))) {
+      (env: MonitoringEnv) =>
+        val thrown:HttpException = the [HttpException] thrownBy env.EF.publish("env", "a1", "a2")(sharedCfg).run
+        thrown.code should equal (999)
+  }
+
+  it should "not try to provision template otherwise" in monitoringEnv() {
+    (env: MonitoringEnv) =>
+      //wait until we see first metric, by that time all template check logic should be completed
+
+      //send test metric
+      val c = env.I.counter("m/test")
+      c.increment
+
+      val stopPublish = env.publish()
+
+      eventually (timeout(Span(5, Seconds))) { env.H.requests.find(r => r.method == "POST") shouldBe defined }
+
+      stopPublish()
+
+      env.H.requests.find(r => r.method == "HEAD") shouldBe defined //expect lookup for template but no attempt to overwrite
+      env.H.requests.find(r => r.method == "PUT") shouldBe empty
+  }
+
+  "publish" should "post first document" in monitoringEnv() {
+    (env: MonitoringEnv) =>
+      val c = env.I.counter("m/test")
+      c.increment
+
+      val stopPublish = env.publish()
+
+      eventually (timeout(Span(5, Seconds))) {
+        env.H.requests.find(r => r.method == "POST" && r.contains("m.test")) shouldBe defined
+      }
+
+      stopPublish()
+  }
+
+  it should "continue posting documents periodically" in monitoringEnv() {
+    (env: MonitoringEnv) =>
+      val c = env.I.counter("m/test")
+      c.increment
+
+      val stopPublish = env.publish()
+
+      //update metric few times (waiting for longer than buffer window) => expect to see documents emitted
+      (1 to 3) foreach {
+        i =>
+          Thread.sleep(100)
+          c.increment
+      }
+
+      eventually (timeout(Span(5, Seconds))) {
+        env.H.requests.count(r => r.method == "POST" && r.contains("m.test")) should be > 3
+      }
+
+      stopPublish()
+  }
+
+  //simulating errors on some requests
+  private def failingHttpLayer(t: Throwable):InMemoryHttpLayer = new InMemoryHttpLayer(mutable.ListBuffer(Rule.defaultRules(sharedCfg): _*)) {
+    var cnt = 0
+
+    override def http(v: HttpOp): Elastic.ES[String] = {
+      cnt = cnt + 1
+      cnt match {
+        case 4 =>
+          Kleisli.kleisli[Task, ElasticCfg, String]((cfg: ElasticCfg) => Task.fail(t))
+        case _ => super.http(v)
+      }
+    }
+  }
+
+  it should "not stop after http error" in monitoringEnv(failingHttpLayer(HttpException(500))) {
+    (env: MonitoringEnv) =>
+      val c = env.I.counter("m/test")
+      c.increment
+
+      val stopPublish = env.publish()
+
+      //update metric few times (waiting for longer than buffer window) => expect to see documents emitted
+      (1 to 10) foreach {
+        i =>
+          Thread.sleep(100)
+          c.increment
+      }
+
+      eventually (timeout(Span(5, Seconds))) {
+        env.H.requests.count(r => r.method == "POST" && r.contains("m.test")) should be > 9
+      }
+
+      stopPublish()
+  }
+
+  it should "retry and proceed after non http error" in monitoringEnv(failingHttpLayer(new IOException("TestException"))) {
+    (env: MonitoringEnv) =>
+      val c = env.I.counter("m/test")
+      c.increment
+
+      val stopPublish = env.publish()
+
+      //update metric few times (waiting for longer than buffer window) => expect to see documents emitted
+      (1 to 10) foreach {
+        i =>
+          Thread.sleep(100)
+          c.increment
+      }
+
+      eventually (timeout(Span(5, Seconds))) {
+        env.H.requests.count(r => r.method == "POST" && r.contains("m.test")) should be > 10
+      }
+
+      stopPublish()
   }
 }

--- a/elastic/src/test/scala/InMemoryHttpLayer.scala
+++ b/elastic/src/test/scala/InMemoryHttpLayer.scala
@@ -1,0 +1,109 @@
+//: ----------------------------------------------------------------------------
+//: Copyright (C) 2015 Verizon.  All Rights Reserved.
+//:
+//:   Licensed under the Apache License, Version 2.0 (the "License");
+//:   you may not use this file except in compliance with the License.
+//:   You may obtain a copy of the License at
+//:
+//:       http://www.apache.org/licenses/LICENSE-2.0
+//:
+//:   Unless required by applicable law or agreed to in writing, software
+//:   distributed under the License is distributed on an "AS IS" BASIS,
+//:   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//:   See the License for the specific language governing permissions and
+//:   limitations under the License.
+//:
+//: ----------------------------------------------------------------------------
+package funnel.elastic
+
+import java.net.URI
+import scalaz.{-\/, \/-, \/, Kleisli}
+import scalaz.concurrent.Task
+import scala.collection._
+
+//Preset response for given (method, path). result is errorCode or body
+case class Rule(method: String = "GET", path: String, result: \/[Int, String])
+
+//Simple "http request" model
+case class Request(method: String = "GET", path: String, body: Option[String]) {
+  def contains(s: String) = body.exists(_.contains(s))
+}
+
+object Rule {
+  def GET(path: String, body: String) = new Rule("GET", path, \/-(body))
+
+  def HEAD(path: String, body: String) = new Rule("HEAD", path, \/-(body))
+
+  def PUT(path: String, body: String) = new Rule("PUT", path, \/-(body))
+
+  def POST(path: String, body: String) = new Rule("POST", path, \/-(body))
+
+  def failedGET(path: String, code: Int) = new Rule("GET", path, -\/(code))
+
+  def failedHEAD(path: String, code: Int) = new Rule("HEAD", path, -\/(code))
+
+  def failedPUT(path: String, code: Int) = new Rule("PUT", path, -\/(code))
+
+  def failedPOST(path: String, code: Int) = new Rule("POST", path, -\/(code))
+
+  def defaultRules(cfg: ElasticCfg) = Seq(
+    HEAD(s"/_template/${cfg.templateName}", ""),  //template lookup
+    Rule.POST(                                    //metric postings
+      //esURL will return URL with host. we only need path part
+      Elastic.esURL(cfg).dropWhile(_ != '/').drop(2).dropWhile(_ != '/'),
+      ""
+    )
+  )
+}
+
+class InMemoryHttpLayer(rules: mutable.ListBuffer[Rule]) extends HttpLayer {
+
+  val requests: mutable.ListBuffer[Request] = mutable.ListBuffer()
+
+  def +(rule: Rule): InMemoryHttpLayer = {
+    this.rules += rule
+    this
+  }
+
+  private def verbString(v: HttpOp) = v match {
+    case x: GET  => "GET"
+    case x: PUT  => "PUT"
+    case x: POST => "POST"
+    case x: HEAD => "HEAD"
+  }
+
+  private def body(v: HttpOp, cfg: ElasticCfg) = v match {
+    case x: PUT  => Some(x.body(cfg))
+    case x: POST => Some(x.body(cfg))
+    case _ => None
+  }
+
+  private def find(verb: String, u: String): Task[String] = {
+    rules.find( r => r.method == verb && r.path == u) match {
+      case None =>
+        Task.fail(HttpException(404))
+      case Some(x) =>
+        x.result match {
+        case -\/(c) => Task.fail(HttpException(c))
+        case \/-(body) => Task.now(body)
+      }
+    }
+  }
+
+  override def http(v: HttpOp): Elastic.ES[String] = {
+    Kleisli.kleisli(
+      (cfg: ElasticCfg) => {
+        requests += Request(verbString(v), new URI(v.url(cfg)).getPath, body(v, cfg))
+        find(verbString(v), new URI(v.url(cfg)).getPath)
+      }
+    )
+  }
+}
+
+object InMemoryHttpLayer {
+  def apply(rules: Seq[Rule]): InMemoryHttpLayer =
+    new InMemoryHttpLayer(mutable.ListBuffer(rules: _*))
+
+  // config passing schema check and allowing posting new metric docs
+  def apply(cfg: ElasticCfg): InMemoryHttpLayer = apply(Rule.defaultRules(cfg))
+}


### PR DESCRIPTION
@timperrett @runarorama please review

Refactored `Elastic` object to move out `Dispatch` code. This simplifies test case creation (added several tests). Also cleaned up a little code around template creation. 

Real bug fix is in the `doPublish` code (lines 135-145). Previous code would retry but if problem is not gone after number of retries then exception will halt "writer" process. Reader will be fine though until buffer is filled. And then we never recover.

Let me know if my `Kliesli` code can be simplified, i am still learning how to use those efficiently.