### PR TITLE
Chemist/Flask improvements

### DIFF
--- a/chemist-aws/src/main/scala/AwsDiscovery.scala
+++ b/chemist-aws/src/main/scala/AwsDiscovery.scala
@@ -97,7 +97,7 @@ class AwsDiscovery(
       f = a.filter((b andThen isFlask)(_))
       _ = metrics.model.hostsFlask.set(f.size)
 
-      _  = log.info(s"instances=${a.size}, monitorable=${m.size}, unmonitorable=${um.size} activeFlasks=${af.size} flasks=${af.size}")
+      _  = log.info(s"[inventory] instances=${a.size}, monitorable=${m.size}, unmonitorable=${um.size} activeFlasks=${af.size} flasks=${af.size}")
 
     } yield DiscoveryInventory(
       m.map(in => TargetID(in.id) -> in.targets),

--- a/chemist-aws/src/main/scala/AwsDiscovery.scala
+++ b/chemist-aws/src/main/scala/AwsDiscovery.scala
@@ -69,65 +69,43 @@ class AwsDiscovery(
   ///////////////////////////// public api /////////////////////////////
 
   /**
-   * List all of the instances in the given AWS account that respond to a rudimentary
-   * verification that Funnel is running on port 5775 and is network accessible.
-   */
-  def listTargets: Task[Seq[(TargetID, Set[Target])]] =
-    ListMonitorable.timeTask {
-      for {
-        i <- instances(isMonitorable)
-        _ = metrics.model.hostsTotal.set(i.size)
-        v <- valid(i)
-        _ = metrics.model.hostsValid.set(v.size)
-      } yield v.map(in => TargetID(in.id) -> in.targets)
-    }
+    * Lists all of the instances in the given AWS account and groups them into
+    * funnel targets and flasks.
+    *
+    * Instance is considered to be monitorable if it responds to a rudimentary
+    * verification that Funnel is running on port 5775 and is network accessible.
+    * If network accessibility check fails then instance is considered unmonitorable.
+    *
+    *
+    */
+  def inventory: Task[DiscoveryInventory] = ListInventory.timeTask {
+    for {
+      a <- readAutoScalingGroups
+      b <- classifier.task
 
-  /**
-   * List all of the instances that failed basic network reachability validation.
-   * In practice, this is the set difference between all discovered instances
-   * and valid ones.
-   */
-  def listUnmonitorableTargets: Task[Seq[(TargetID, Set[Target])]] =
-    ListUnmonitorable.timeTask {
-      for {
-        i <- instances(isMonitorable)
-        _ = metrics.model.hostsTotal.set(i.size)
-        v <- valid(i)
-        _ = metrics.model.hostsValid.set(v.size)
-        bad = i.toSet &~ v.toSet
-        _ = metrics.model.hostsInValid.set(bad.size)
-      } yield bad.toList.map(in => TargetID(in.id) -> in.targets)
-    }
+      _ = metrics.model.hostsTotal.set(a.size)
+      m = a.filter((b andThen isMonitorable)(_))
+      _ = metrics.model.hostsValid.set(m.size)
 
-  /**
-   * List all of the instances in the given AWS account and figure out which ones of
-   * those instances meets the classification criterion for being considered
-   * an active flask.
-   */
-  def listActiveFlasks: Task[Seq[Flask]] =
-    ListActiveFlasks.timeTask {
-      for {
-        a <- instances(isActiveFlask)
-        _ = metrics.model.hostsTotal.set(a.size)
-        b  = a.map(i => Flask(FlaskID(i.id), i.location))
-        _ = metrics.model.hostsActiveFlask.set(b.size)
-      } yield b
-    }
+      v <- valid(a)
+      um = a.toSet &~ v.toSet
+      _ = metrics.model.hostsInValid.set(um.size)
 
-  /**
-   * List all instances that classify as a flask, regardless of working state.
-   * This function is only ever called during migration / re-election of an orchestrating
-   * leader chemist.
-   */
-  def listAllFlasks: Task[Seq[Flask]] =
-    ListFlasks.timeTask {
-      for {
-        a <- instances(isFlask)
-        _ = metrics.model.hostsTotal.set(a.size)
-        b  = a.map(i => Flask(FlaskID(i.id), i.location))
-        _ = metrics.model.hostsFlask.set(b.size)
-      } yield b
-    }
+      af = a.filter((b andThen isActiveFlask)(_))
+      _ = metrics.model.hostsActiveFlask.set(af.size)
+
+      f = a.filter((b andThen isFlask)(_))
+      _ = metrics.model.hostsFlask.set(f.size)
+
+      _  = log.info(s"instances=${a.size}, monitorable=${m.size}, unmonitorable=${um.size} activeFlasks=${af.size} flasks=${af.size}")
+
+    } yield DiscoveryInventory(
+      m.map(in => TargetID(in.id) -> in.targets),
+      um.toSeq.map(in => TargetID(in.id) -> in.targets),
+      af.map(i => Flask(FlaskID(i.id), i.location)),
+      f.map(i => Flask(FlaskID(i.id), i.location))
+    )
+  }
 
   /**
    * Lookup the `AwsInstance` for a given `InstanceID`; `AwsInstance` returned contains all

--- a/chemist-aws/src/main/scala/AwsDiscovery.scala
+++ b/chemist-aws/src/main/scala/AwsDiscovery.scala
@@ -102,8 +102,8 @@ class AwsDiscovery(
     } yield DiscoveryInventory(
       m.map(in => TargetID(in.id) -> in.targets),
       um.toSeq.map(in => TargetID(in.id) -> in.targets),
-      af.map(i => Flask(FlaskID(i.id), i.location)),
-      f.map(i => Flask(FlaskID(i.id), i.location))
+      af.map(i => Flask(FlaskID(i.id), i.location.copy(port = 5775))), //FIXME: we really need to be reading control port from EC2 tags!
+      f.map(i => Flask(FlaskID(i.id), i.location.copy(port = 5775)))
     )
   }
 

--- a/chemist-aws/src/main/scala/AwsInstance.scala
+++ b/chemist-aws/src/main/scala/AwsInstance.scala
@@ -18,25 +18,44 @@ package funnel
 package chemist
 package aws
 
-import java.net.URI
-import scalaz.{\/,\/-,-\/,NonEmptyList}
+import scalaz.NonEmptyList
 
 /**
  * Represents an EC2 machine in AWS. Every single machine in AWS should
  * be monitorable, or at least have a monitorable location, even if it
- * is not ultimatly reachable.
+ * is not ultimately reachable.
  *
- * Tags are used heavily to datamine what kind of intstance we're looking
+ * Tags are used heavily to datamine what kind of instance we're looking
  * at, during various parts of the process. Your instances need the following
  * tags set on the instance (as a minimum):
  *
  * - `funnel:target:name`: e.g. myapp
  * - `funnel:target:version`: e.g. 1.2.3
- * - `funnel:target:qualifier`: e.g. XdfGeq4 (uniqley identify this deployment)
+ * - `funnel:target:qualifier`: e.g. XdfGeq4 (uniquely identify this deployment)
  * - `funnel:mirror:uri-template`: e.g. http://@host:5775; lets chemist
  *                                 know where to connect to for mirroring
  *
  * Do be aware that EC2 has a 10 tag limit (so dumb!)
+  *
+  * TODO: Future idea:
+  *
+  *  Migrate to a single 'funnel' tag with URI value (saves 3 EC2 tags, can add parameters easily) and encode
+  *  additional info including:
+  *    - role in the funnel ecosystem (e.g. chemist, flask, metric producer agent)
+  *    - port where control APIs are exposed (may be different from metric port)
+  *    - telemetry port for zeromq
+  *    - (optional) scope. chemist/flasks/agents will avoid collecting metrics from
+  *      a different scope. This will allow us to deploy multiple independent sets of chemist/flasks
+  *      (for testing or to control different groups of resources. E.g. we can have
+  *       dedicated chemist/flask deployment to monitor most critical or heaviest or backend agent.
+  *       Or we can do test deployments in the same environment.)
+  *
+  * URI format for new tag:
+  *   role://app-name/version/qualifier?mirror=port&telemetry=port&format=jsonOrZeromq&control=port
+  * Examples:
+  *   chemist://chemist/5.2.123/XdfGeq4?metricsPort=port&metricsFormat=json&controlPort=port&scope=default
+  *   flask://flask/5.2.123/XdfGeq4?metricsPort=port&metricsProtocol=http&controlPort=port&scope=test
+  *   target://s2s-admin/1.2.3/sadasfas?metricsPort=port&metricsProtocol=http&telemetry=port
  */
 case class AwsInstance(
   id: String,
@@ -49,7 +68,7 @@ case class AwsInstance(
   def application: Option[Application] = {
     for {
       b <- tags.get(AwsTagKeys.name) orElse tags.get("type") orElse tags.get("Name")
-      c <- tags.get(AwsTagKeys.version) orElse tags.get("revision") orElse(Some("unknown"))
+      c <- tags.get(AwsTagKeys.version) orElse tags.get("revision") orElse Some("unknown")
       d  = tags.get("aws:cloudformation:stack-name")
             .flatMap(_.split('-').lastOption.find(_.length > 3))
     } yield Application(

--- a/chemist-aws/src/main/scala/DefaultClassifier.scala
+++ b/chemist-aws/src/main/scala/DefaultClassifier.scala
@@ -23,7 +23,7 @@ import scalaz.concurrent.Task
 /**
  * This default implementation does not properly handle the various upgrade
  * cases that you might encounter when migrating from one set of clusters to
- * another, but it instead provided as a default where all avalible flasks
+ * another, but it instead provided as a default where all available flasks
  * and chemists are are "active". There are a set of upgrade scenarios where
  * you do not want to mirror from an existing flask cluster, so they are not
  * targets, nor are they active flasks.
@@ -31,7 +31,7 @@ import scalaz.concurrent.Task
  * Providing this function with a task return type so that extensions can do I/O
  * if they need too (clearly a cache locally would be needed in that case)
  *
- * It is highly recomended you override this with your own classification logic.
+ * It is highly recommended you override this with your own classification logic.
  */
 object DefaultClassifier extends Classifier[AwsInstance]{
   import Classification._
@@ -40,7 +40,7 @@ object DefaultClassifier extends Classifier[AwsInstance]{
   private[funnel] val Chemist = "chemist"
 
   def isApplication(prefix: String)(i: AwsInstance): Boolean =
-    i.application.map(_.name.trim.toLowerCase.startsWith(prefix)).getOrElse(false)
+    i.application.exists(_.name.trim.toLowerCase.startsWith(prefix))
 
   def isFlask(i: AwsInstance): Boolean =
     isApplication(Flask)(i)
@@ -51,8 +51,8 @@ object DefaultClassifier extends Classifier[AwsInstance]{
   val task: Task[AwsInstance => Classification] = {
     Task.delay {
       instance =>
-        if(isFlask(instance)) ActiveFlask
-        else if(isChemist(instance)) ActiveChemist
+        if (isFlask(instance)) ActiveFlask
+        else if (isChemist(instance)) ActiveChemist
         else ActiveTarget
     }
   }

--- a/chemist-aws/src/main/scala/aws/ASG.scala
+++ b/chemist-aws/src/main/scala/aws/ASG.scala
@@ -71,7 +71,8 @@ object ASG {
     Task(fetch(Nil).map(g =>
       Group(
         name      = g.getAutoScalingGroupName,
-        instances = g.getInstances.asScala.toSeq,
+        //ignore "starting"/"terminating" instances
+        instances = g.getInstances.asScala.filterNot(_.getLifecycleState == "InService"),
         tags      = tags(g))
       ))(funnel.chemist.Chemist.serverPool)
   }

--- a/chemist-aws/src/main/scala/aws/ASG.scala
+++ b/chemist-aws/src/main/scala/aws/ASG.scala
@@ -18,9 +18,7 @@ package funnel
 package aws
 
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.auth.{AWSCredentials,BasicAWSCredentials}
-import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.Address
+import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.autoscaling.{AmazonAutoScaling,AmazonAutoScalingClient}
 import com.amazonaws.services.autoscaling.model.{
   DescribeAutoScalingGroupsRequest,

--- a/chemist-aws/src/main/scala/aws/ASG.scala
+++ b/chemist-aws/src/main/scala/aws/ASG.scala
@@ -72,7 +72,7 @@ object ASG {
       Group(
         name      = g.getAutoScalingGroupName,
         //ignore "starting"/"terminating" instances
-        instances = g.getInstances.asScala.filterNot(_.getLifecycleState == "InService"),
+        instances = g.getInstances.asScala.filter(_.getLifecycleState == "InService"),
         tags      = tags(g))
       ))(funnel.chemist.Chemist.serverPool)
   }

--- a/chemist-aws/src/main/scala/metrics.scala
+++ b/chemist-aws/src/main/scala/metrics.scala
@@ -24,10 +24,7 @@ object metrics {
   val LifecycleEvents = counter("chemist/lifecycle/events", 0, "number of lifecycle events within a given window")
 
   object discovery {
-    val ListMonitorable = lapTimer("chemist/discovery/list/monitorable")
-    val ListUnmonitorable = lapTimer("chemist/discovery/list/unmonitorable")
-    val ListFlasks = lapTimer("chemist/discovery/list/flasks")
-    val ListActiveFlasks = lapTimer("chemist/discovery/list/activeFlasks")
+    val ListInventory = lapTimer("chemist/discovery/inventory")
     val LookupManyAws = lapTimer("chemist/discovery/aws/lookups")
     val LookupAwsFailure = counter("chemist/discovery/aws/errors")
     val ValidateLatency = lapTimer("chemist/discovery/validate")

--- a/chemist-static/src/main/scala/StaticDiscovery.scala
+++ b/chemist-static/src/main/scala/StaticDiscovery.scala
@@ -20,10 +20,10 @@ package chemist
 import scalaz.concurrent.Task
 
 class StaticDiscovery(targets: Map[TargetID, Set[Target]], flasks: Map[FlaskID, Flask]) extends Discovery {
-  def listTargets: Task[Seq[(TargetID, Set[Target])]] = Task.delay(targets.toSeq)
-  def listUnmonitorableTargets: Task[Seq[(TargetID, Set[Target])]] = Task.now(Seq.empty)
-  def listAllFlasks: Task[Seq[Flask]] = Task.delay(flasks.values.toSeq)
-  def listActiveFlasks: Task[Seq[Flask]] = Task.delay(flasks.values.toSeq)
+  def inventory: Task[DiscoveryInventory] = Task.delay(
+    DiscoveryInventory(targets.toSeq, Seq.empty, flasks.values.toSeq, flasks.values.toSeq)
+  )
+
   def lookupFlask(id: FlaskID): Task[Flask] = Task.delay(flasks(id))	// Can obviously cause the Task to fail
   def lookupTargets(id: TargetID): Task[Set[Target]] = Task.delay(targets(id))	// Can obviously cause the Task to fail
 }

--- a/chemist/src/main/scala/Chemist.scala
+++ b/chemist/src/main/scala/Chemist.scala
@@ -104,6 +104,19 @@ trait Chemist[A <: Platform]{
 object Chemist {
   type Flow[A] = Process[Task,Context[A]]
 
+  /**
+    * Context represents "current" state of the world before A is handled.
+    * This could be used to figure what is the best way to handle the A.
+    * E.g. what chose flask to observe it based on the flask load.
+    *
+    * Note that if Context is transformed then distribution need to be updated in the new Context.
+    * I.e. if we decide to emit command to discard stream then we should drop it from distribution too.
+    *
+    * Note that this representation might be somewhat out of date as other actions could have
+    * been performed after Context was built. E.g. if we discovered 100 new targets at the same time
+    * and process them one by one then we will build 100 Context with same distribution.
+    * As we process new targets real distribution will evolve but snapshots will stay the same.
+    */
   case class Context[A](distribution: Sharding.Distribution, value: A)
 
   /*********************************************************************************/

--- a/chemist/src/main/scala/Chemist.scala
+++ b/chemist/src/main/scala/Chemist.scala
@@ -18,7 +18,6 @@ package funnel
 package chemist
 
 import java.net.{ InetSocketAddress, Socket, URI }
-import journal.Logger
 import scalaz.{\/,Kleisli}
 import scalaz.syntax.kleisli._
 import scalaz.concurrent.{Task,Strategy}
@@ -85,7 +84,7 @@ trait Chemist[A <: Platform]{
    */
   def listUnmonitorableTargets: ChemistK[List[Target]] =
     config.flatMapK( cfg =>
-      cfg.discovery.listUnmonitorableTargets.map(_.toList.flatMap(_._2)))
+      cfg.discovery.inventory.map(_.unmonitorableTargets.toList.flatMap(_._2)))
 
   /**
    * Initialize the chemist service by trying to create the various AWS resources

--- a/chemist/src/main/scala/Discovery.scala
+++ b/chemist/src/main/scala/Discovery.scala
@@ -57,19 +57,16 @@ trait Discovery {
     c == ActiveChemist
 
   /**
-   * The reason this is not simply the inverted version of `isActiveFlask`
-   * is that when asking for targets, we specifically do not want any
-   * Flasks, active or otherwise, because mirroring a Flask from another
+   * The reason we exclude inactive flasks is because  mirroring a Flask from another
    * Flask risks a cascading failure due to key amplification (essentially
    * mirroring the mirrored whilst its mirroring etc).
    *
-   * To mitigate this, we specifically call out anything that is not
-   * classified as an `ActiveTarget`
+   * For "active" flasks we assume Sharder is aware of this and will not assign "flask" streams
+   * to other flasks. For inactive flasks Sharder can not figure that stream belongs to flask.
+   * To mitigate the issue we specifically exclude inactive flasks.
    *
    * @see funnel.chemist.Classifier
    */
   def isMonitorable(c: Classification): Boolean =
-    c == ActiveTarget ||
-    c == ActiveChemist ||
-    c == InactiveChemist
+    c != InactiveFlask
 }

--- a/chemist/src/main/scala/Discovery.scala
+++ b/chemist/src/main/scala/Discovery.scala
@@ -19,13 +19,16 @@ package chemist
 
 import scalaz.concurrent.Task
 
+case class DiscoveryInventory(targets: Seq[(TargetID,Set[Target])],
+                              unmonitorableTargets: Seq[(TargetID,Set[Target])],
+                              allFlasks: Seq[Flask],
+                              activeFlasks: Seq[Flask])
+
 trait Discovery {
-  def listTargets: Task[Seq[(TargetID,Set[Target])]]
-  def listUnmonitorableTargets: Task[Seq[(TargetID,Set[Target])]]
-  def listAllFlasks: Task[Seq[Flask]]
-  def listActiveFlasks: Task[Seq[Flask]]
   def lookupTargets(id: TargetID): Task[Set[Target]]
   def lookupFlask(id: FlaskID): Task[Flask]
+
+  def inventory: Task[DiscoveryInventory]
 
   ///////////////////////////// filters /////////////////////////////
 

--- a/chemist/src/main/scala/Json.scala
+++ b/chemist/src/main/scala/Json.scala
@@ -121,6 +121,20 @@ object JSON {
     jEmptyObject
   }
 
+  def encodeAllTargets(targets: Seq[Target], time: Date): Json = {
+    ("type" := "AllTargets") ->:
+    ("time" := time) ->:
+    ("targets" -> Json.array(
+      targets.map {
+        t =>
+          ("cluster" := t.cluster) ->:
+            ("uri" := t.uri) ->:
+            jEmptyObject
+      }: _*)
+    ) ->:
+    jEmptyObject
+  }
+
   def encodeNewFlask(f: Flask, time: Date): Json = {
     ("type" := "NewFlask") ->:
     ("flask" := f.id) ->:
@@ -172,6 +186,7 @@ object JSON {
   implicit val platformEventToJson: EncodeJson[PlatformEvent] =
     EncodeJson {
       case e @ PlatformEvent.NewTarget(t) => encodeNewTarget(t, e.time)
+      case e @ PlatformEvent.AllTargets(t) => encodeAllTargets(t, e.time)
       case e @ PlatformEvent.NewFlask(f) => encodeNewFlask(f, e.time)
       case e @ PlatformEvent.TerminatedTarget(u) => encodeTerminatedTarget(u, e.time)
       case e @ PlatformEvent.TerminatedFlask(f) => encodeTerminatedFlask(f, e.time)

--- a/chemist/src/main/scala/Pipeline.scala
+++ b/chemist/src/main/scala/Pipeline.scala
@@ -72,7 +72,7 @@ object Pipeline {
      * distribution is the specific work that needs to take place, represented as a distribution
      */
     def newTarget(target: Target, sharder: Sharder)(d: Distribution): (Distribution, Redistribute) = {
-      val proposed = sharder.distribution(Set(target))(d)._2 // drop the seq, as its not needed
+      val proposed = sharder.distribution(Set(target))(d) // drop the seq, as its not needed
 
       //there is nothing to stop and we only need to issue command for new target
       (proposed, Redistribute(Distribution.empty, proposed.map(_.intersect(Set(target)))))
@@ -89,7 +89,7 @@ object Pipeline {
         val newTargets = allTargets.diff(current)
         val missingTargets = current.diff(allTargets)
 
-        val proposed = shd.distribution(newTargets)(old)._2.map(_.diff(missingTargets))
+        val proposed = shd.distribution(newTargets)(old).map(_.diff(missingTargets))
 
         //redistribute command assumes we are not sending "redundant" requests to monitor something being monitored
         val proposedDelta = proposed.map(_.intersect(newTargets))
@@ -114,7 +114,7 @@ object Pipeline {
       val empty: Distribution = flasks.foldLeft(Distribution.empty)(
         (a,b) => a.insert(b, Set.empty)).insert(flask, Set.empty)
 
-      val proposed: Distribution = shd.distribution(targets)(empty)._2
+      val proposed: Distribution = shd.distribution(targets)(empty)
 
       val r1 = proposed.fold(Redistribute.empty){ (f, t, r) =>
         if(f.id == flask.id) r.update(f, stopping = Set.empty, starting = t)

--- a/chemist/src/main/scala/PlatformEvent.scala
+++ b/chemist/src/main/scala/PlatformEvent.scala
@@ -26,6 +26,7 @@ sealed abstract class PlatformEvent {
 object PlatformEvent {
   final case class NewTarget(target: Target) extends PlatformEvent
   final case class NewFlask(flask: Flask) extends PlatformEvent
+  final case class AllTargets(targets: Seq[Target]) extends PlatformEvent
   final case class TerminatedTarget(u: URI) extends PlatformEvent
   final case class TerminatedFlask(f: FlaskID) extends PlatformEvent
   final case object NoOp extends PlatformEvent

--- a/chemist/src/main/scala/Sharding.scala
+++ b/chemist/src/main/scala/Sharding.scala
@@ -17,11 +17,8 @@
 package funnel
 package chemist
 
-import scalaz.{==>>,Order}
-import scalaz.concurrent.Task
-import funnel.ClusterName
+import scalaz.==>>
 import java.net.URI
-import journal.Logger
 
 object Sharding {
 
@@ -30,8 +27,6 @@ object Sharding {
   object Distribution {
     def empty: Distribution = ==>>()
   }
-
-  private lazy val log = Logger[Sharding.type]
 
   /**
    * obtain a list of flasks ordered by flasks with the least

--- a/chemist/src/main/scala/Sharding.scala
+++ b/chemist/src/main/scala/Sharding.scala
@@ -26,6 +26,8 @@ object Sharding {
 
   object Distribution {
     def empty: Distribution = ==>>()
+
+    def empty(flasks: Seq[Flask]) = ==>>.fromList(flasks.toList.map(f => f -> Set.empty[Target]))
   }
 
   /**

--- a/chemist/src/main/scala/flask.scala
+++ b/chemist/src/main/scala/flask.scala
@@ -67,8 +67,8 @@ object Flask {
       all =>
         val (errors, success) = all.toVector.separate
 
-        metrics.deadFlasks.set(errors.size)
-        metrics.liveFlasks.set(success.size)
+        metrics.ModelDeadFlasks.set(errors.size)
+        metrics.ModelLiveFlasks.set(success.size)
 
         errors.foreach {
           e => log.error(s"[gatherAssigned] dead flask=${e._1}, problem=${e._2}")
@@ -79,7 +79,7 @@ object Flask {
         )
 
         val cnt = dis.values.map(_.size).sum
-        metrics.knownSources.set(cnt)
+        metrics.ModelAssignedSources.set(cnt)
 
         log.info(s"[gatherAssigned] distribution stats: flasks=${dis.keySet.size} targets=$cnt")
         log.debug(s"[gatherAssigned] distribution details: $dis")

--- a/chemist/src/main/scala/flask.scala
+++ b/chemist/src/main/scala/flask.scala
@@ -72,7 +72,6 @@ object Flask {
 
         errors.foreach {
           e => log.error(s"[gatherAssigned] dead flask=${e._1}, problem=${e._2}")
-            print(s"[gatherAssigned] dead flask=${e._1}, problem=${e._2}\n")
         }
 
         val dis = success.foldLeft(Distribution.empty)(

--- a/chemist/src/main/scala/metrics.scala
+++ b/chemist/src/main/scala/metrics.scala
@@ -20,11 +20,22 @@ package chemist
 import funnel.instruments._
 
 object metrics {
-  val GatherAssignedLatency = lapTimer("chemist/pipeline/gather-assigned-latency")
-  val MonitorCommandLatency = lapTimer("chemist/commands/monitor")
-  val UnmonitorCommandLatency = lapTimer("chemist/commands/unmonitor")
+  val ErrorsFlask     = counter("chemist/errors/flask") 
+  val ErrorsDiscovery = counter("chemist/errors/discovery") 
 
-  val deadFlasks   = numericGauge("chemist/flasks/dead", 0)
-  val liveFlasks   = numericGauge("chemist/flasks/live", 0)
-  val knownSources = numericGauge("chemist/flasks/sources", 0)
+  val GatherAssignedLatency = lapTimer("chemist/io/flask/gather-assigned") 
+  val MonitorCallLatency = lapTimer("chemist/io/flask/monitor") 
+  val UnmonitorCallLatency = lapTimer("chemist/io/flask/unmonitor") 
+
+  val DiscoveryLatency = lapTimer("chemist/io/discovery") 
+
+  val MonitorCommands   = counter("chemist/model/commands/monitor") 
+  val UnmonitorCommands = counter("chemist/model/commands/unmonitor") 
+
+  val ModelAssignedSources = numericGauge("chemist/model/streams/assigned", 0) 
+  val ModelAllSources  = numericGauge("chemist/model/streams/all", 0)
+  val ModelDeadSources = numericGauge("chemist/model/streams/dead", 0)
+
+  val ModelDeadFlasks   = numericGauge("chemist/model/flasks/dead", 0) 
+  val ModelLiveFlasks   = numericGauge("chemist/model/flasks/live", 0) 
 }

--- a/chemist/src/main/scala/sinks.scala
+++ b/chemist/src/main/scala/sinks.scala
@@ -87,7 +87,7 @@ object sinks {
         }
       }
 
-      (Task.delay(log.info(s"received redistribute command: $p")) <*
+      (Task.delay(log.info(s"received redistribute command: stop=${Sharding.targets(p.stop).size} start=${Sharding.targets(p.start).size} cmd=$p")) <*
        Nondeterminism[Task].gatherUnordered(stopping) <*
        Nondeterminism[Task].gatherUnordered(starting)).handle {
         //this can fail as we did not handle errors for "unmonitor" commands

--- a/chemist/src/test/scala/PipelineCheck.scala
+++ b/chemist/src/test/scala/PipelineCheck.scala
@@ -82,8 +82,11 @@ object PipelineCheck extends Properties("Pipeline") {
     d <- arbitrary[Distribution]
     e <- arbitrary[PlatformEvent]
   } yield Context(d, e)
+
   implicit lazy val arbContextOfPlatformEvent: Arbitrary[Context[PlatformEvent]] =
     Arbitrary(genContextOfPlatformEvent)
+
+  private val gatherIdentity = (in: Distribution) => Task.delay(in)
 
   property("newTarget works") = forAll { (t: Target, s: Sharder, d: Distribution) =>
     val (nd, cmd) = Pipeline.handle.newTarget(t, s)(d)
@@ -96,7 +99,7 @@ object PipelineCheck extends Properties("Pipeline") {
   property("transform works") = forAll { (sd: StaticDiscovery, s: Sharder, c: Context[PlatformEvent]) =>
     val d: Distribution = c.distribution
     val e: PlatformEvent = c.value
-    val cp: Context[Plan] = Pipeline.transform(sd, s)(c).run
+    val cp: Context[Plan] = Pipeline.transform(sd, s, gatherIdentity)(c).run
     val nd: Distribution = cp.distribution
     val p: Plan = cp.value
 

--- a/chemist/src/test/scala/PipelineSpec.scala
+++ b/chemist/src/test/scala/PipelineSpec.scala
@@ -17,10 +17,14 @@
 package funnel
 package chemist
 
-import org.scalatest.{FlatSpec,Matchers}
+import org.scalatest.{FlatSpec, Matchers}
+
 import scala.concurrent.duration._
 import scalaz.stream.Process
 import java.net.URI
+
+import scalaz.==>>
+import scalaz.concurrent.Task
 
 class PipelineSpec extends FlatSpec with Matchers {
   import PlatformEvent._
@@ -71,28 +75,40 @@ class PipelineSpec extends FlatSpec with Matchers {
     "http://localhost:4006/stream/now?type=%22String%22".target
   )
 
+  def sizePlans(lst: List[Plan]): Int =
+    lst.map {
+      case Redistribute(stop, start) =>
+        Sharding.targets(stop).size + Sharding.targets(start).size
+      case Distribute(d) =>
+        Sharding.targets(d).size
+      case _ => 0
+    }.sum
+
   /************************ plan checking ************************/
 
-  it should "correctly distribute the work to one of the flasks" in {
-    val p1: Flow[PlatformEvent] =
-      List("http://localhost:8888/stream/previous".target).flow
+  "transform" should "correctly distribute the work to one of the flasks" in {
+    val t = "http://localhost:8888/stream/previous".target
+    val e: Context[PlatformEvent] = Context(d1, NewTarget(t))
 
-    (p1.map(transform(TestDiscovery, RandomSharding)).runLast.run
-      .get.value match {
-        case Distribute(d) => d.values.flatMap(identity).length
-        case _ => 0
-      }) should equal(1)
+    transform(TestDiscovery, RandomSharding)(e).run.value match {
+      case Redistribute(stop, start) =>
+        stop.values.flatten.size should equal(0)
+        start.values.flatten.size should equal(1)
+        start.values.flatten.toSet should equal(Set(t))
+      case _ => fail("unexpected command")
+    }
   }
 
-  // this is a little lame
-  it should "produce a plan for every input target" in {
+  it should "produce a ONE command to monitor for every input target" in {
     val accum: List[Plan] =
       t1.flow.map(transform(TestDiscovery, RandomSharding))
-      .scan(List.empty[Plan])((a,b) => a :+ b.value)
+      .scan(List.empty[Plan])((a,b) => a :+ b.run.value)
       .runLast.run
       .toList
       .flatten
+
     accum.length should equal (t1.length)
+    sizePlans(accum) should equal(t1.length)
   }
 
   /************************ handlers ************************/
@@ -108,17 +124,41 @@ class PipelineSpec extends FlatSpec with Matchers {
 
     Sharding.shards(n).size should equal (d.keys.size + 1)
     Sharding.targets(n).size should equal (t1.size + t2.size)
+  }
 
-    // println("\n\n >>>>> origional")
-    // d.pretty()
+  "handle.rediscovery" should "correctly stop work" in {
+    val d = Distribution.empty
+      .insert(flask01, t1.toSet)
+      .insert(flask02, t2.toSet)
 
-    // println("\n\n >>>>> stopping")
-    // r.stop.pretty()
+    val (n, r) = handle.rediscovery(Set.empty, d)(LFRRSharding)
 
-    // println("\n\n >>>>> starting")
-    // r.start.pretty()
+    Sharding.shards(n).size should equal (d.keys.size)
+    Sharding.targets(n).size should equal (0)
+    Sharding.targets(r.start).size should be (0)
+    Sharding.targets(r.stop).size should be (t1.size + t2.size)
+  }
 
-    // println("\n\n >>>>> distribution")
-    // n.pretty()
+  it should "correctly start new work" in {
+    val (n, r) = handle.rediscovery(t2.toSet, d1)(LFRRSharding)
+
+    Sharding.shards(n).size should equal (d1.keys.size)
+    Sharding.targets(n).size should equal (t2.size)
+    Sharding.targets(r.stop).size should be (0)
+    Sharding.targets(r.start).size should be (t2.size)
+  }
+
+  it should "correctly rebalance work" in {
+    //distribution is mix of targets that will stay and targets that will disappear
+    val d = Distribution.empty
+      .insert(flask01, t1.take(3).toSet ++ t2.take(1).toSet)
+      .insert(flask02, t1.takeRight(3).toSet ++ t2.takeRight(1).toSet)
+
+    val (n, r) = handle.rediscovery(t2.toSet, d)(LFRRSharding)
+
+    Sharding.shards(n).size should equal (d.keys.size)
+    Sharding.targets(n).size should equal (t2.size)
+    Sharding.targets(r.stop).size should be (3 + 3)
+    Sharding.targets(r.start).size should be (t2.size - 1 - 1)
   }
 }

--- a/chemist/src/test/scala/ShardingProp.scala
+++ b/chemist/src/test/scala/ShardingProp.scala
@@ -17,10 +17,6 @@
 package funnel
 package chemist
 
-import java.net.URI
-import java.util.UUID
-import scalaz.==>>
-import LocationIntent._
 import Sharding.Distribution
 import org.scalacheck.{Properties,Gen}
 import org.scalacheck.Prop.{ BooleanOperators, forAll }
@@ -35,10 +31,10 @@ object ShardingProp extends Properties("sharding") {
     genDistribution,
     genSharder
   ){ (w: Set[Target], d: Distribution, shd: Sharder) =>
-      val (s, newdist) = RandomSharding.distribution(w)(d)
-      ("assign all the given targets if the distribution has flasks" |:
-        (if(!d.hasFlasks){ newdist.values.flatten.size == 0 }
-        else { newdist.values.flatten.size == (d.values.flatten.size + w.size) }))
+      val newdist = RandomSharding.distribution(w)(d)
+      "assign all the given targets if the distribution has flasks" |:
+        (if(!d.hasFlasks){ newdist.values.flatten.isEmpty }
+        else { newdist.values.flatten.size == (d.values.flatten.size + w.size) })
     }
 
   property("deduplication") = forAll(
@@ -46,7 +42,8 @@ object ShardingProp extends Properties("sharding") {
     genDistribution
   ){ (w: Set[Target], d: Distribution) =>
     val work = w ++ d.elemAt(0).map { case (k,v) => v }.getOrElse(Set.empty)
-    ("should remove existing targets" |: (Sharding.deduplicate(work)(d) == w))
+
+    "should remove existing targets" |: (Sharding.deduplicate(work)(d) == w)
   }
 
 }

--- a/chemist/src/test/scala/SinksSpec.scala
+++ b/chemist/src/test/scala/SinksSpec.scala
@@ -132,4 +132,18 @@ class SinksSpec extends FlatSpec with Matchers {
     f.commandsCompleted shouldBe 5
     f.commandsFailed shouldBe 1 //we should not try to run anything after failure
   }
+
+  it should "not issue commands if there is no work to do" in {
+    val f = UnstableFlask("bad")
+
+    // if we get plans with no actionable items then we should not call flask
+    Process.apply(
+      Context[Plan](Distribution.empty, Redistribute(Distribution.empty, Distribution.empty)),
+      Context[Plan](Distribution.empty, Distribute(Distribution.empty))
+    ).toSource.to(sinks.unsafeNetworkIO(f, q)).run.run
+
+    f.commandsCompleted shouldBe 0
+    f.commandsFailed shouldBe 0
+
+  }
 }

--- a/chemist/src/test/scala/TestConfig.scala
+++ b/chemist/src/test/scala/TestConfig.scala
@@ -31,10 +31,9 @@ class TestConfig extends PlatformConfig {
   val state: StateCache = MemoryStateCache
 
   class StaticDiscovery(targets: Map[TargetID, Set[Target]], flasks: Map[FlaskID, Flask]) extends Discovery {
-    def listTargets: Task[Seq[(TargetID, Set[Target])]] = Task.delay(targets.toSeq)
-    def listUnmonitorableTargets: Task[Seq[(TargetID, Set[Target])]] = Task.now(Seq.empty)
-    def listAllFlasks: Task[Seq[Flask]] = Task.delay(flasks.values.toSeq)
-    def listActiveFlasks: Task[Seq[Flask]] = Task.delay(flasks.values.toSeq)
+    def inventory: Task[DiscoveryInventory] = Task.delay(
+      DiscoveryInventory(targets.toSeq, Seq.empty, flasks.values.toSeq, flasks.values.toSeq)
+    )
     def lookupFlask(id: FlaskID): Task[Flask] = Task.delay(flasks(id))	// Can obviously cause the Task to fail
     def lookupTargets(id: TargetID): Task[Set[Target]] = Task.delay(targets(id))	// Can obviously cause the Task to fail
   }

--- a/chemist/src/test/scala/TestDiscovery.scala
+++ b/chemist/src/test/scala/TestDiscovery.scala
@@ -20,10 +20,7 @@ package chemist
 import scalaz.concurrent.Task
 
 object TestDiscovery extends Discovery {
-  def listActiveFlasks: Task[Seq[Flask]] = ???
-  def listAllFlasks: Task[Seq[Flask]] = ???
-  def listTargets: Task[Seq[(TargetID, Set[Target])]] = ???
-  def listUnmonitorableTargets: Task[Seq[(TargetID, Set[Target])]] = ???
+  def inventory: Task[DiscoveryInventory] = ???
   def lookupFlask(id: funnel.chemist.FlaskID): Task[Flask] = ???
   def lookupTarget(id: funnel.chemist.TargetID): Task[Seq[Target]] = ???
   def lookupTargets(id: funnel.chemist.TargetID): Task[Set[Target]] = ???

--- a/elastic/src/main/scala/Elastic.scala
+++ b/elastic/src/main/scala/Elastic.scala
@@ -48,17 +48,8 @@ object Elastic {
 
   private[this] val log = Logger[Elastic.type]
 
-  private[funnel] def daemonThreads(name: String) = new ThreadFactory {
-    def newThread(r: Runnable) = {
-      val t = Executors.defaultThreadFactory.newThread(r)
-      t.setDaemon(true)
-      t.setName(name)
-      t
-    }
-  }
-
   val esPool: ExecutorService =
-    Executors.newFixedThreadPool(8, daemonThreads("elastic-publisher-thread"))
+    Executors.newFixedThreadPool(8, Monitoring.daemonThreads("elastic-publisher-thread"))
 
   /**
    *

--- a/elastic/src/main/scala/Elastic.scala
+++ b/elastic/src/main/scala/Elastic.scala
@@ -38,7 +38,6 @@ object Elastic {
   import scalaz.syntax.kleisli._
   import scalaz.syntax.monad._ // pulls in *>
   import scala.concurrent.duration._
-  import metrics._
 
   type SourceURL = String
   type ExperimentID = String
@@ -108,19 +107,19 @@ object Elastic {
   /**
    * retries any non-HTTP errors with exponential backoff
    */
-  def retry[A](task: Task[A]): Task[A] = {
+  def retry[A](task: Task[A])(m: ElasticMetrics): Task[A] = {
     val schedule = Stream.iterate(2)(_ * 2).take(30).map(_.seconds)
     val t = task.attempt.flatMap(_.fold(
       {
         case e: HttpException =>
           Task.delay {
-            if (e.serverError) HttpResponse5xx.increment
-            else if (e.clientError) HttpResponse4xx.increment
+            if (e.serverError) m.HttpResponse5xx.increment
+            else if (e.clientError) m.HttpResponse4xx.increment
           }.flatMap(_ => Task.fail(e))
         case e =>
           Task.delay {
             log.error(s"Error contacting ElasticSearch: $e. Retrying...")
-            NonHttpErrors.increment
+            m.NonHttpErrors.increment
           } >>= (_ => Task.fail(e))
       },
       a => Task.now(a)
@@ -139,24 +138,24 @@ object Elastic {
   def bufferAndPublish(
     flaskName: String,
     flaskCluster: String
-  )(M: Monitoring, E: Strategy, H: HttpLayer
+  )(M: Monitoring, E: Strategy, H: HttpLayer, iselfie: ElasticMetrics
   )(jsonStream: ElasticCfg => Process[Task, Json]): ES[Unit] = {
     def doPublish(de: Process[Task, Json], cfg: ElasticCfg): Process[Task, Unit] =
       de to constant(
-        (json: Json) => retry(HttpResponse2xx.timeTask(
+        (json: Json) => retry(iselfie.HttpResponse2xx.timeTask(
           for {
             //delaying task is important here. Otherwise we will not really retry to send http request
             u <- Task.delay(esURL)
             _ <- H.http(POST(u, Reader((cfg: ElasticCfg) => json.nospaces)))(cfg)
           } yield ()
-        )).attempt.map {
+        ))(iselfie).attempt.map {
           case \/-(v) => ()
           case -\/(t) =>
             //if we fail to publish metric, proceed to the next one
             // TODO: consider circuit breaker on ES failures (embed into HttpLayer)
             // TODO: how does publishing dies when flasks stops monitoring target? do we release resources?
             log.warn(s"[elastic] failed to publish. error=$t data=$json ")
-            metrics.BufferDropped.increment
+            iselfie.BufferDropped.increment
             ()
         }
       )
@@ -167,7 +166,7 @@ object Elastic {
         (cfg: ElasticCfg) =>
           log.info(s"Initializing Elastic buffer of size ${cfg.bufferSize}...")
           val buffer = ScalazHack.observableCircularBuffer[Json](
-            cfg.bufferSize, metrics.BufferDropped, metrics.BufferUsed
+            cfg.bufferSize, iselfie.BufferDropped, iselfie.BufferUsed
           )(E)
 
           log.info(s"Started Elastic subscription")

--- a/elastic/src/main/scala/ElasticFlattened.scala
+++ b/elastic/src/main/scala/ElasticFlattened.scala
@@ -55,7 +55,7 @@ import scalaz.concurrent.Strategy.Executor
  *   }
  * }
  */
-case class ElasticFlattened(M: Monitoring, H: HttpLayer = SharedHttpLayer.H){
+case class ElasticFlattened(M: Monitoring, ISelfie: Instruments, H: HttpLayer = SharedHttpLayer.H){
   import Elastic._
   import argonaut._, Argonaut._
   import Process._
@@ -75,6 +75,9 @@ case class ElasticFlattened(M: Monitoring, H: HttpLayer = SharedHttpLayer.H){
       sdf.format(d)
     }
   }
+
+  //metrics to report own status
+  val metrics = new ElasticMetrics(ISelfie)
 
   /**
    *
@@ -166,7 +169,7 @@ case class ElasticFlattened(M: Monitoring, H: HttpLayer = SharedHttpLayer.H){
     flaskCluster: String
   ): ES[Unit] = {
     val E = Executor(Elastic.esPool)
-    bufferAndPublish(flaskNameOrHost, flaskCluster)(M, E, H){ cfg =>
+    bufferAndPublish(flaskNameOrHost, flaskCluster)(M, E, H, metrics){ cfg =>
 
       val data: Process[Task, Option[Datapoint[Any]]] =
         Monitoring.

--- a/elastic/src/main/scala/ElasticFlattened.scala
+++ b/elastic/src/main/scala/ElasticFlattened.scala
@@ -21,7 +21,7 @@ import java.net.URI
 import scalaz.concurrent.Task
 import scala.concurrent.duration.Duration
 import scalaz.stream._
-import java.util.{Date,TimeZone}
+import java.util.{Date, TimeZone}
 import java.text.SimpleDateFormat
 import scalaz.concurrent.Strategy.Executor
 
@@ -165,8 +165,7 @@ case class ElasticFlattened(M: Monitoring, H: HttpLayer = SharedHttpLayer.H){
     flaskNameOrHost: String,
     flaskCluster: String
   ): ES[Unit] = {
-    //TODO: consider dedicated pool for ES publishing, need to guarantee we will not starve when mirroring many agents
-    val E = Executor(Monitoring.defaultPool)
+    val E = Executor(Elastic.esPool)
     bufferAndPublish(flaskNameOrHost, flaskCluster)(M, E, H){ cfg =>
 
       val data: Process[Task, Option[Datapoint[Any]]] =

--- a/elastic/src/main/scala/metrics.scala
+++ b/elastic/src/main/scala/metrics.scala
@@ -20,10 +20,7 @@ package elastic
 //Needed for static initialization of JVM Metrics
 import scala.concurrent.duration._
 
-object metrics {
-  //report these metrics every 30 seconds
-  val i = new Instruments(bufferTime = 30 seconds)
-
+class ElasticMetrics(i: Instruments) {
   val DroppedDocErrors = i.counter("elastic/errors/dropped")
   val NonHttpErrors    = i.counter("elastic/errors/other")
   val HttpResponse5xx  = i.counter("elastic/http/5xx")

--- a/elastic/src/test/scala/ExplodedSpec.scala
+++ b/elastic/src/test/scala/ExplodedSpec.scala
@@ -28,7 +28,8 @@ class ExplodedSpec extends FlatSpec with Matchers {
 
   val scheduler = Monitoring.schedulingPool
   val S = Executor(Monitoring.serverPool)
-  val E = ElasticExploded(Monitoring.default)
+  val I = new Instruments(Monitoring.default)
+  val E = ElasticExploded(Monitoring.default, I)
 
   "elasticGroup" should "emit on timeout" in {
     val cfg = ElasticCfg("localhost", "index", "type", "dateFormat", "template", None, List("k"), 5.seconds, 5.seconds)

--- a/elastic/src/test/scala/ExplodedTest.scala
+++ b/elastic/src/test/scala/ExplodedTest.scala
@@ -35,7 +35,7 @@ object ExplodedTest extends P("elastic") {
     //d <- Gen.posNum[Double]
   } yield Option(Datapoint(k, 3 /*d */)) */
 
-  val E = ElasticExploded(Monitoring.default)
+  val E = ElasticExploded(Monitoring.default, new Instruments(Monitoring.default))
 
   import E._
 

--- a/elastic/src/test/scala/FlattendedSpec.scala
+++ b/elastic/src/test/scala/FlattendedSpec.scala
@@ -31,7 +31,7 @@ import scalaz.concurrent.Task
 import scalaz.stream.Process
 
 class FlattenedSpec extends FlatSpec with Matchers with Eventually {
-  val F = ElasticFlattened(Monitoring.default)
+  val F = ElasticFlattened(Monitoring.default, new Instruments(Monitoring.default))
 
   def point =
     Datapoint[Any](Key[Double](s"now/${java.util.UUID.randomUUID.toString}", Units.Count, "some description",
@@ -98,8 +98,8 @@ class FlattenedSpec extends FlatSpec with Matchers with Eventually {
 
     val M = Monitoring.instance(ES = pool, windowSize = 50.millis)
 
-    val ef = ElasticFlattened(M, httpLayer)
     val instruments = new Instruments(M, bufferTime = 20 millis)
+    val ef = ElasticFlattened(M, instruments, httpLayer)
 
     val env = MonitoringEnv(M, instruments, ef, httpLayer)
 

--- a/flask/src/main/scala/Flask.scala
+++ b/flask/src/main/scala/Flask.scala
@@ -46,7 +46,11 @@ class Flask(options: Options, val I: Instruments) {
   val log = Logger[this.type]
 
   val Selfie = Monitoring.instance
-  val ISelfie = new Instruments(Selfie)
+
+  //30 seconds is workaround attempting to reduce number of documents we produce
+  // it is NOT a real solution but i move it here as it was used in elastic module before refactoring
+  //TODO: revisit it
+  val ISelfie = new Instruments(Selfie, bufferTime = 30 seconds)
   val mirrorDatapoints = ISelfie.counter("mirror/datapoints")
 
   val S = MonitoringServer.start(I.monitoring, options.funnelPort)
@@ -120,12 +124,12 @@ class Flask(options: Options, val I: Instruments) {
 
     options.elasticExploded.foreach { elastic =>
       log.info("Booting the elastic-exploded search sink...")
-      runAsync(ElasticExploded(I.monitoring).publish(flaskName, flaskCluster)(elastic))
+      runAsync(ElasticExploded(I.monitoring, ISelfie).publish(flaskName, flaskCluster)(elastic))
     }
 
     options.elasticFlattened.foreach { elastic =>
       log.info("Booting the elastic-flattened search sink...")
-      runAsync(ElasticFlattened(I.monitoring).publish(options.environment, flaskName, flaskCluster)(elastic))
+      runAsync(ElasticFlattened(I.monitoring, ISelfie).publish(options.environment, flaskName, flaskCluster)(elastic))
     }
   }
 }

--- a/flask/src/main/scala/Flask.scala
+++ b/flask/src/main/scala/Flask.scala
@@ -50,7 +50,7 @@ class Flask(options: Options, val I: Instruments) {
   //30 seconds is workaround attempting to reduce number of documents we produce
   // it is NOT a real solution but i move it here as it was used in elastic module before refactoring
   //TODO: revisit it
-  val ISelfie = new Instruments(Selfie, bufferTime = 30 seconds)
+  val ISelfie = new Instruments(Selfie, bufferTime = 30.seconds)
   val mirrorDatapoints = ISelfie.counter("mirror/datapoints")
 
   val S = MonitoringServer.start(I.monitoring, options.funnelPort)


### PR DESCRIPTION
Number of changes:
   - agent: fix how metrics are reported in experimental context (always report non experimental metric)
   - flask: use dedicated thread pool for elastic updates
   - flask: use ISelfie instruments to report metrics
   - chemist: list ASGs once per "discovery" 
   - chemist: fix redistribution logic (and convert most of operations to use redistribute to request to drop "dead" targets)
   - chemist: do not send "empty" commands to flasks
   - chemist: only discover "InService" instances
   - chemist: expose flask own streams to chemist (so chemist can detect if they die, but ensure flask streams are only assigned to the same flask)
   - chemist: revisit sharding APIs

With these changes there is one outstanding problem - chemist and flask identity for "flask" AWS stack is not the same (flask thinks it is "flask-5.x.y" and chemist thinks it it "flask-5.x.y-someWeithSuffix"). Therefore chemist will ask flask to drop own streams and start monitoring "new" ones. 

I am considering passing external "name" to the flask, so it will know how it is known to the world. Or we can detect "aliases" based on stream URIs (however, flask can use localhost to stream local metrics). Or we can later change protocol between flask and chemist to report "own" streams in a separate way.

I've also hardcoded "5775" as "control" port for flask for now. This will be gone in future PRs.




