### PR TITLE
add web hook for AWS status/load balancer calls

### DIFF
--- a/http/src/main/scala/MonitoringServer.scala
+++ b/http/src/main/scala/MonitoringServer.scala
@@ -109,6 +109,12 @@ class MonitoringServer(M: Monitoring, port: Int, keyTTL: Duration = 36.hours) {
     SSE.writeKeys(M.distinctKeys.filter(keyQuery(req.getRequestURI)), sink)
   }
 
+  private val emptyResponse = "[]".getBytes
+
+  protected def handleStatus(req: HttpExchange): Unit = {
+    flush(200, emptyResponse, req)
+  }
+
   protected def handleNow(M: Monitoring, label: String, req: HttpExchange): Unit = {
     import argonaut.EncodeJson
     val m = Monitoring.snapshot(M).run
@@ -248,6 +254,7 @@ class MonitoringServer(M: Monitoring, port: Int, keyTTL: Duration = 36.hours) {
         case "keys"    :: tl               => handleKeys(M, tl.mkString("/"), req)
         case "stream"  :: "keys" :: Nil    => handleKeysStream(M, req)
         case "stream"  :: tl               => handleStream(M, tl.mkString("/"), req)
+        case "status"  :: Nil              => handleStatus(req)
         case now                           => handleNow(M, now.mkString("/"), req)
       }
     }


### PR DESCRIPTION
Bugfix

The default endpoint /status was getting called and taking snapshots of state to filter for the meaningless "status" prefix.

These snapshots became very contentious with many threads building up while waiting for their state snapshot.

@timperrett 