### PR TITLE
Gws 2488 potential deadlock in agent

### DIFF
--- a/core/src/main/scala/Instruments.scala
+++ b/core/src/main/scala/Instruments.scala
@@ -132,14 +132,10 @@ class Instruments(val monitoring: Monitoring = Monitoring.default,
 
     log.debug(s"adding keys from periodic of $ks and the triple Buffer of $nps")
 
-    val t1: List[Task[I => Task[Unit]]] =
-      List(monitoring.topicWithKey(ks.now)(nps.one),
-           monitoring.topicWithKey(ks.previous, true)(nps.two),
-           monitoring.topicWithKey(ks.sliding)(nps.three))
-
-    val t2: Task[List[Kleisli[Task, I, Unit]]] = t1.traverse(_.map(Kleisli(_)))
-    val t3: Task[Kleisli[Task, I, Unit]]       = t2.map(_.traverseU_(identity))
-    val t = t3.map(_.run)
+    val t = List(monitoring.topicWithKey(ks.now)(nps.one),
+                 monitoring.topicWithKey(ks.previous, true)(nps.two),
+                 monitoring.topicWithKey(ks.sliding)(nps.three)).traverse(
+      _.map(Kleisli(_))).map(_.traverseU_(identity)).map(_.run)
     (ks, t)
   }
 


### PR DESCRIPTION
Addresses https://github.com/oncue/funnel/issues/50

This puts the operation to add metrics on its own thread pool.  This will allow the application thread to continue without having the potential impact of a slow flask.

Outstanding questions: 
Is it possible to submit so many new metrics that a fork operation would block as well?  
^ Is this a reasonable fear?